### PR TITLE
fix(tauri): use CSS pixels for embedded window rect

### DIFF
--- a/e2e/test/tauri/window.spec.ts
+++ b/e2e/test/tauri/window.spec.ts
@@ -1,6 +1,104 @@
 import { expect } from '@wdio/globals';
 import { browser, withExecuteOptions } from '@wdio/tauri-service';
 
+interface NativeWindowMetrics {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale_factor: number;
+}
+
+interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+const WINDOW_RECT_TOLERANCE = 1;
+
+async function getNativeWindowMetrics(): Promise<NativeWindowMetrics> {
+  return browser.tauri.execute(({ core }) => core.invoke('get_window_bounds')) as Promise<NativeWindowMetrics>;
+}
+
+async function getViewportSize(): Promise<ViewportSize> {
+  return browser.execute<ViewportSize>(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
+}
+
+function expectWithinTolerance(actual: number, expected: number): void {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(WINDOW_RECT_TOLERANCE);
+}
+
+describe('Embedded WebDriver WindowRect CSS pixel semantics', () => {
+  beforeEach(async function () {
+    if (process.env.DRIVER_PROVIDER !== 'embedded') {
+      this.skip();
+    }
+    await browser.tauri.switchWindow('main');
+  });
+
+  it('should return the native outer rect in logical pixels', async () => {
+    const metrics = await getNativeWindowMetrics();
+    const rect = await browser.getWindowRect();
+
+    expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
+    expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
+    expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+    expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+  });
+
+  it('should set the outer rect in logical pixels', async () => {
+    const originalRect = await browser.getWindowRect();
+    const targetRect = {
+      x: originalRect.x + 20,
+      y: originalRect.y + 20,
+      width: 720,
+      height: 540,
+    };
+
+    try {
+      const rect = await browser.setWindowRect(targetRect.x, targetRect.y, targetRect.width, targetRect.height);
+      const metrics = await getNativeWindowMetrics();
+
+      expectWithinTolerance(rect.x, targetRect.x);
+      expectWithinTolerance(rect.y, targetRect.y);
+      expectWithinTolerance(rect.width, targetRect.width);
+      expectWithinTolerance(rect.height, targetRect.height);
+      expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
+      expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
+      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+    } finally {
+      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
+    }
+  });
+
+  it('should set the outer size in logical pixels without shrinking the viewport', async () => {
+    const originalRect = await browser.getWindowRect();
+    const originalViewport = await getViewportSize();
+    const targetRect = { width: 720, height: 540 };
+
+    try {
+      const rect = await browser.setWindowRect(null, null, targetRect.width, targetRect.height);
+      const metrics = await getNativeWindowMetrics();
+      const viewport = await getViewportSize();
+
+      expectWithinTolerance(rect.x, originalRect.x);
+      expectWithinTolerance(rect.y, originalRect.y);
+      expectWithinTolerance(rect.width, targetRect.width);
+      expectWithinTolerance(rect.height, targetRect.height);
+      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+      expectWithinTolerance(viewport.width - originalViewport.width, rect.width - originalRect.width);
+      expectWithinTolerance(viewport.height - originalViewport.height, rect.height - originalRect.height);
+    } finally {
+      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
+    }
+  });
+});
+
 describe('Multi-Window Support', () => {
   beforeEach(async () => {
     // Ensure we're on the main window before each test

--- a/e2e/test/tauri/window.spec.ts
+++ b/e2e/test/tauri/window.spec.ts
@@ -31,74 +31,6 @@ function expectWithinTolerance(actual: number, expected: number): void {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(WINDOW_RECT_TOLERANCE);
 }
 
-describe('Embedded WebDriver WindowRect CSS pixel semantics', () => {
-  beforeEach(async function () {
-    if (process.env.DRIVER_PROVIDER !== 'embedded') {
-      this.skip();
-    }
-    await browser.tauri.switchWindow('main');
-  });
-
-  it('should return the native outer rect in logical pixels', async () => {
-    const metrics = await getNativeWindowMetrics();
-    const rect = await browser.getWindowRect();
-
-    expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
-    expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
-    expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
-    expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
-  });
-
-  it('should set the outer rect in logical pixels', async () => {
-    const originalRect = await browser.getWindowRect();
-    const targetRect = {
-      x: originalRect.x + 20,
-      y: originalRect.y + 20,
-      width: 720,
-      height: 540,
-    };
-
-    try {
-      const rect = await browser.setWindowRect(targetRect.x, targetRect.y, targetRect.width, targetRect.height);
-      const metrics = await getNativeWindowMetrics();
-
-      expectWithinTolerance(rect.x, targetRect.x);
-      expectWithinTolerance(rect.y, targetRect.y);
-      expectWithinTolerance(rect.width, targetRect.width);
-      expectWithinTolerance(rect.height, targetRect.height);
-      expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
-      expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
-      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
-      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
-    } finally {
-      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
-    }
-  });
-
-  it('should set the outer size in logical pixels without shrinking the viewport', async () => {
-    const originalRect = await browser.getWindowRect();
-    const originalViewport = await getViewportSize();
-    const targetRect = { width: 720, height: 540 };
-
-    try {
-      const rect = await browser.setWindowRect(null, null, targetRect.width, targetRect.height);
-      const metrics = await getNativeWindowMetrics();
-      const viewport = await getViewportSize();
-
-      expectWithinTolerance(rect.x, originalRect.x);
-      expectWithinTolerance(rect.y, originalRect.y);
-      expectWithinTolerance(rect.width, targetRect.width);
-      expectWithinTolerance(rect.height, targetRect.height);
-      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
-      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
-      expectWithinTolerance(viewport.width - originalViewport.width, rect.width - originalRect.width);
-      expectWithinTolerance(viewport.height - originalViewport.height, rect.height - originalRect.height);
-    } finally {
-      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
-    }
-  });
-});
-
 describe('Multi-Window Support', () => {
   beforeEach(async () => {
     // Ensure we're on the main window before each test
@@ -268,6 +200,77 @@ describe('application window tests', () => {
       await browser.tauri.switchWindow('main');
       const title = await browser.getTitle();
       expect(title).toMatch(/Tauri.*E2E Test App/);
+    }
+  });
+});
+
+describe('Embedded WebDriver WindowRect CSS pixel semantics', () => {
+  before(async function () {
+    if (process.env.DRIVER_PROVIDER !== 'embedded') {
+      this.skip();
+    }
+
+    // Window rects are meaningful only after the splash fixture makes main visible.
+    await browser.tauri.execute(({ core }) => core.invoke('switch_to_main'));
+    await browser.tauri.switchWindow('main');
+  });
+
+  it('should return the native outer rect in logical pixels', async () => {
+    const metrics = await getNativeWindowMetrics();
+    const rect = await browser.getWindowRect();
+
+    expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
+    expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
+    expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+    expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+  });
+
+  it('should set the outer rect in logical pixels', async () => {
+    const originalRect = await browser.getWindowRect();
+    const targetRect = {
+      x: originalRect.x + 20,
+      y: originalRect.y + 20,
+      width: 720,
+      height: 540,
+    };
+
+    try {
+      const rect = await browser.setWindowRect(targetRect.x, targetRect.y, targetRect.width, targetRect.height);
+      const metrics = await getNativeWindowMetrics();
+
+      expectWithinTolerance(rect.x, targetRect.x);
+      expectWithinTolerance(rect.y, targetRect.y);
+      expectWithinTolerance(rect.width, targetRect.width);
+      expectWithinTolerance(rect.height, targetRect.height);
+      expectWithinTolerance(rect.x, Math.round(metrics.x / metrics.scale_factor));
+      expectWithinTolerance(rect.y, Math.round(metrics.y / metrics.scale_factor));
+      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+    } finally {
+      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
+    }
+  });
+
+  it('should set the outer size in logical pixels without shrinking the viewport', async () => {
+    const originalRect = await browser.getWindowRect();
+    const originalViewport = await getViewportSize();
+    const targetRect = { width: 720, height: 540 };
+
+    try {
+      const rect = await browser.setWindowRect(null, null, targetRect.width, targetRect.height);
+      const metrics = await getNativeWindowMetrics();
+      const viewport = await getViewportSize();
+
+      expectWithinTolerance(rect.x, originalRect.x);
+      expectWithinTolerance(rect.y, originalRect.y);
+      expectWithinTolerance(rect.width, targetRect.width);
+      expectWithinTolerance(rect.height, targetRect.height);
+      expectWithinTolerance(rect.width, Math.round(metrics.width / metrics.scale_factor));
+      expectWithinTolerance(rect.height, Math.round(metrics.height / metrics.scale_factor));
+      expectWithinTolerance(viewport.width - originalViewport.width, rect.width - originalRect.width);
+      expectWithinTolerance(viewport.height - originalViewport.height, rect.height - originalRect.height);
+    } finally {
+      await browser.setWindowRect(originalRect.x, originalRect.y, originalRect.width, originalRect.height);
     }
   });
 });

--- a/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
+++ b/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
@@ -31,6 +31,15 @@ struct WindowBounds {
     height: u32,
 }
 
+#[derive(Debug, Serialize)]
+struct WindowMetrics {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct ScreenshotOptions {
     format: Option<String>,
@@ -74,14 +83,16 @@ struct DiskInfo {
 
 // Basic Tauri Commands for testing
 #[tauri::command]
-async fn get_window_bounds(window: Window) -> Result<WindowBounds, String> {
+async fn get_window_bounds(window: Window) -> Result<WindowMetrics, String> {
     let position = window.outer_position().map_err(|e| e.to_string())?;
-    let size = window.outer_size().map_err(|e| e.to_string())?;
-    Ok(WindowBounds {
+    let outer_size = window.outer_size().map_err(|e| e.to_string())?;
+    let scale_factor = window.scale_factor().map_err(|e| e.to_string())?;
+    Ok(WindowMetrics {
         x: position.x,
         y: position.y,
-        width: size.width,
-        height: size.height,
+        width: outer_size.width,
+        height: outer_size.height,
+        scale_factor,
     })
 }
 

--- a/packages/tauri-plugin-webdriver/README.md
+++ b/packages/tauri-plugin-webdriver/README.md
@@ -224,6 +224,12 @@ Port resolution order:
 | POST | `/session/{id}/window/minimize` | Minimize |
 | POST | `/session/{id}/window/fullscreen` | Fullscreen |
 
+`Get Window Rect` and `Set Window Rect` use CSS pixels, as required by the
+[W3C WebDriver Window Rect commands](https://www.w3.org/TR/webdriver2/#set-window-rect).
+On desktop platforms, the plugin converts Tauri's physical outer-window bounds
+using the window's current display scale factor. Position changes are completed
+before a requested size is applied, including moves between displays.
+
 ### Frames
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -5,7 +5,9 @@ use tauri::webview::Cookie as TauriCookie;
 use tauri::{Runtime, WebviewWindow};
 
 #[cfg(desktop)]
-use tauri::{PhysicalPosition, PhysicalSize};
+use tauri::Listener;
+#[cfg(desktop)]
+use tauri::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 
 use tauri::Manager;
 
@@ -30,6 +32,143 @@ pub struct WindowRect {
     pub y: i32,
     pub width: u32,
     pub height: u32,
+}
+
+#[cfg(desktop)]
+fn physical_window_rect_to_logical(
+    position: PhysicalPosition<i32>,
+    size: PhysicalSize<u32>,
+    scale_factor: f64,
+) -> WindowRect {
+    let position = position.to_logical::<i32>(scale_factor);
+    let size = size.to_logical::<u32>(scale_factor);
+
+    WindowRect {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+    }
+}
+
+#[cfg(desktop)]
+fn physical_window_chrome_to_logical(
+    outer: PhysicalSize<u32>,
+    inner: PhysicalSize<u32>,
+    scale_factor: f64,
+) -> LogicalSize<u32> {
+    PhysicalSize::new(
+        outer.width.saturating_sub(inner.width),
+        outer.height.saturating_sub(inner.height),
+    )
+    .to_logical(scale_factor)
+}
+
+#[cfg(desktop)]
+async fn apply_window_change<R, F>(
+    window: &WebviewWindow<R>,
+    event_name: &'static str,
+    operation: &'static str,
+    change: F,
+) -> Result<(), WebDriverErrorResponse>
+where
+    R: Runtime,
+    F: FnOnce() -> tauri::Result<()>,
+{
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let listener_id = window.once(event_name, move |_| {
+        let _ = sender.send(());
+    });
+
+    if let Err(error) = change() {
+        window.unlisten(listener_id);
+        return Err(WebDriverErrorResponse::unknown_error(&format!(
+            "Failed to {operation}: {error}"
+        )));
+    }
+
+    match tokio::time::timeout(std::time::Duration::from_secs(1), receiver).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) => Err(WebDriverErrorResponse::unknown_error(&format!(
+            "Window event listener closed while waiting to {operation}"
+        ))),
+        Err(_) => {
+            window.unlisten(listener_id);
+            Err(WebDriverErrorResponse::unknown_error(&format!(
+                "Timed out waiting to {operation}"
+            )))
+        }
+    }
+}
+
+#[cfg(all(test, desktop))]
+mod window_rect_tests {
+    use super::*;
+
+    #[test]
+    fn converts_physical_window_rect_at_common_scale_factors() {
+        let cases = [
+            (
+                PhysicalPosition::new(-200, 150),
+                PhysicalSize::new(720, 540),
+                1.0,
+                WindowRect {
+                    x: -200,
+                    y: 150,
+                    width: 720,
+                    height: 540,
+                },
+            ),
+            (
+                PhysicalPosition::new(-151, 251),
+                PhysicalSize::new(1000, 750),
+                1.25,
+                WindowRect {
+                    x: -121,
+                    y: 201,
+                    width: 800,
+                    height: 600,
+                },
+            ),
+            (
+                PhysicalPosition::new(-400, 300),
+                PhysicalSize::new(1440, 1080),
+                2.0,
+                WindowRect {
+                    x: -200,
+                    y: 150,
+                    width: 720,
+                    height: 540,
+                },
+            ),
+        ];
+
+        for (position, size, scale_factor, expected) in cases {
+            let actual = physical_window_rect_to_logical(position, size, scale_factor);
+
+            assert_eq!(actual.x, expected.x);
+            assert_eq!(actual.y, expected.y);
+            assert_eq!(actual.width, expected.width);
+            assert_eq!(actual.height, expected.height);
+        }
+    }
+
+    #[test]
+    fn converts_physical_window_chrome_before_subtracting_it() {
+        let retina_chrome = physical_window_chrome_to_logical(
+            PhysicalSize::new(1440, 1080),
+            PhysicalSize::new(1440, 1032),
+            2.0,
+        );
+        let fractional_chrome = physical_window_chrome_to_logical(
+            PhysicalSize::new(1251, 1001),
+            PhysicalSize::new(1000, 750),
+            1.25,
+        );
+
+        assert_eq!(retina_chrome, LogicalSize::new(0, 24));
+        assert_eq!(fractional_chrome, LogicalSize::new(201, 201));
+    }
 }
 
 /// Frame identifier for switching frames
@@ -469,10 +608,9 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
         );
         let result = self.evaluate_js(&script).await?;
 
-        let value = result
-            .get("value")
-            .cloned()
-            .ok_or_else(|| WebDriverErrorResponse::unknown_error("element center script returned no value"))?;
+        let value = result.get("value").cloned().ok_or_else(|| {
+            WebDriverErrorResponse::unknown_error("element center script returned no value")
+        })?;
 
         #[derive(serde::Deserialize)]
         struct Center {
@@ -1472,17 +1610,25 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Get window rectangle (position and size)
     #[cfg(desktop)]
     async fn get_window_rect(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        if let Ok(position) = self.window().outer_position() {
-            if let Ok(size) = self.window().outer_size() {
-                return Ok(WindowRect {
-                    x: position.x,
-                    y: position.y,
-                    width: size.width,
-                    height: size.height,
-                });
-            }
-        }
-        Ok(WindowRect::default())
+        let scale_factor = self.window().scale_factor().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get window scale factor: {error}"
+            ))
+        })?;
+        let position = self.window().outer_position().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get window position: {error}"
+            ))
+        })?;
+        let size = self.window().outer_size().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!("Failed to get window size: {error}"))
+        })?;
+
+        Ok(physical_window_rect_to_logical(
+            position,
+            size,
+            scale_factor,
+        ))
     }
 
     #[cfg(mobile)]
@@ -1496,38 +1642,79 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     ) -> Result<WindowRect, WebDriverErrorResponse> {
         // Exit fullscreen/maximized state before setting rect
         // Otherwise the window manager may ignore our size/position request
-        if self.window().is_fullscreen().unwrap_or(false) {
-            let _ = self.window().set_fullscreen(false);
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        if self.window().is_maximized().unwrap_or(false) {
-            let _ = self.window().unmaximize();
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-
-        let _ = self
-            .window()
-            .set_position(PhysicalPosition::new(rect.x, rect.y));
-
-        // Calculate chrome/decoration size to set outer size correctly
-        // On Windows/Linux, set_size sets inner size, but we want to set outer size
-        let (chrome_width, chrome_height) = if let (Ok(outer), Ok(inner)) =
-            (self.window().outer_size(), self.window().inner_size())
-        {
-            (
-                outer.width.saturating_sub(inner.width),
-                outer.height.saturating_sub(inner.height),
+        let is_fullscreen = self.window().is_fullscreen().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to query window fullscreen state: {error}"
+            ))
+        })?;
+        if is_fullscreen {
+            apply_window_change(
+                self.window(),
+                "tauri://resize",
+                "exit window fullscreen state",
+                || self.window().set_fullscreen(false),
             )
-        } else {
-            (0, 0)
-        };
+            .await?;
+        }
+        let is_maximized = self.window().is_maximized().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to query window maximized state: {error}"
+            ))
+        })?;
+        if is_maximized {
+            apply_window_change(
+                self.window(),
+                "tauri://resize",
+                "restore maximized window",
+                || self.window().unmaximize(),
+            )
+            .await?;
+        }
 
-        // Set inner size = requested outer size - chrome
-        let inner_width = rect.width.saturating_sub(chrome_width);
-        let inner_height = rect.height.saturating_sub(chrome_height);
-        let _ = self
-            .window()
-            .set_size(PhysicalSize::new(inner_width, inner_height));
+        let scale_factor = self.window().scale_factor().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get window scale factor: {error}"
+            ))
+        })?;
+        let position = self.window().outer_position().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get window position: {error}"
+            ))
+        })?;
+        let outer_size = self.window().outer_size().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get outer window size: {error}"
+            ))
+        })?;
+        let inner_size = self.window().inner_size().map_err(|error| {
+            WebDriverErrorResponse::unknown_error(&format!(
+                "Failed to get inner window size: {error}"
+            ))
+        })?;
+
+        let current_rect = physical_window_rect_to_logical(position, outer_size, scale_factor);
+        let chrome_size = physical_window_chrome_to_logical(outer_size, inner_size, scale_factor);
+
+        if rect.x != current_rect.x || rect.y != current_rect.y {
+            apply_window_change(self.window(), "tauri://move", "set window position", || {
+                self.window()
+                    .set_position(LogicalPosition::new(rect.x, rect.y))
+            })
+            .await?;
+        }
+
+        if rect.width != current_rect.width || rect.height != current_rect.height {
+            // Tauri sets the inner size. Chrome is measured in logical pixels before any
+            // display move so physical metrics from different scale factors are never mixed.
+            let inner_size = LogicalSize::new(
+                rect.width.saturating_sub(chrome_size.width),
+                rect.height.saturating_sub(chrome_size.height),
+            );
+            apply_window_change(self.window(), "tauri://resize", "set window size", || {
+                self.window().set_size(inner_size)
+            })
+            .await?;
+        }
 
         self.get_window_rect().await
     }

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -65,6 +65,15 @@ fn physical_window_chrome_to_logical(
 }
 
 #[cfg(desktop)]
+const WINDOW_CHANGE_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Apply a native window change and wait for Tauri to confirm it via `event_name`.
+///
+/// Only a failure of the native call itself is an error. A window manager may clamp or
+/// ignore a request, in which case the confirming event never arrives — `Set Window Rect`
+/// is best-effort, so callers report the rect the window actually ended up with instead
+/// of failing the command.
+#[cfg(desktop)]
 async fn apply_window_change<R, F>(
     window: &WebviewWindow<R>,
     event_name: &'static str,
@@ -87,18 +96,18 @@ where
         )));
     }
 
-    match tokio::time::timeout(std::time::Duration::from_secs(1), receiver).await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(_)) => Err(WebDriverErrorResponse::unknown_error(&format!(
-            "Window event listener closed while waiting to {operation}"
-        ))),
+    match tokio::time::timeout(WINDOW_CHANGE_EVENT_TIMEOUT, receiver).await {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            tracing::debug!("Window event listener closed while waiting to {operation}");
+        }
         Err(_) => {
             window.unlisten(listener_id);
-            Err(WebDriverErrorResponse::unknown_error(&format!(
-                "Timed out waiting to {operation}"
-            )))
+            tracing::debug!("Timed out waiting to {operation}");
         }
     }
+
+    Ok(())
 }
 
 #[cfg(all(test, desktop))]

--- a/packages/tauri-plugin-webdriver/src/platform/executor.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/executor.rs
@@ -1731,8 +1731,10 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Maximize window
     #[cfg(desktop)]
     async fn maximize_window(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        let _ = self.window().maximize();
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        apply_window_change(self.window(), "tauri://resize", "maximize window", || {
+            self.window().maximize()
+        })
+        .await?;
         self.get_window_rect().await
     }
 
@@ -1746,8 +1748,13 @@ pub trait PlatformExecutor<R: Runtime>: Send + Sync {
     /// Set window to fullscreen
     #[cfg(desktop)]
     async fn fullscreen_window(&self) -> Result<WindowRect, WebDriverErrorResponse> {
-        let _ = self.window().set_fullscreen(true);
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        apply_window_change(
+            self.window(),
+            "tauri://resize",
+            "enter window fullscreen state",
+            || self.window().set_fullscreen(true),
+        )
+        .await?;
         self.get_window_rect().await
     }
 


### PR DESCRIPTION
## Description

Fixes the embedded Tauri WebDriver server's desktop `Get Window Rect` and `Set Window Rect` implementation so the W3C values are expressed in CSS/logical pixels instead of Tauri physical pixels.

On a Retina display, the existing implementation returned and accepted physical dimensions. A Tauri window reported by WebDriver as `1320x860` at DPR 2 therefore exposed only a `660x430` DOM viewport, and setting a WebDriver size could shrink the application to half of the requested logical size.

This change:

- converts Tauri physical outer position and size through `to_logical()` using the current window scale factor;
- uses `LogicalPosition` and `LogicalSize` when applying WebDriver rects;
- measures the window decoration in logical pixels before a possible display move, avoiding stale physical metrics being combined with a new display scale factor;
- waits for Tauri's `tauri://move` and `tauri://resize` events instead of relying on fixed delays, and reports a WebDriver `unknown error` if a native operation fails. A window manager may clamp or ignore a request, so an unobserved event is logged and the resulting rect is returned rather than failing the command; the same wait now also covers `maximize` and `fullscreen`;
- applies position before size when both are requested and skips native setters whose requested value is unchanged;
- documents the CSS-pixel contract without changing the endpoint or public response shape.

The behavior follows the [W3C Set Window Rect command](https://www.w3.org/TR/webdriver2/#set-window-rect) and Tauri's [`PhysicalSize::to_logical`](https://docs.rs/tauri/latest/tauri/dpi/struct.PhysicalSize.html#method.to_logical) API.

### Regression evidence

The embedded E2E was first run against the previous implementation. It failed while the existing window tests passed:

```text
should return the native outer rect in logical pixels
Received difference: 2492px

should set the outer size in logical pixels without shrinking the viewport
Received difference: 360px
```

With the fix, the same Retina run observed a `720x540` WebDriver rect backed by `1440x1080` physical bounds at scale factor 2. The DOM viewport changed by the same logical delta, and all 14 window tests passed.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code style/refactoring (no functional changes)
- [ ] Internal/tooling change (build scripts, CI, etc.)
- [ ] Performance improvement

## Scope

- [ ] `scope:electron` - Electron service and CDP bridge
- [x] `scope:tauri` - Tauri service and plugin

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/desktop-mobile/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project (passes `pnpm lint`)
- [x] I have added tests that prove my fix is effective
- [ ] All new and existing tests pass (`pnpm test`)
- [x] I have updated the documentation
- [x] My changes generate no new TypeScript errors (`pnpm typecheck`)

A direct root `pnpm test` is not a CI-equivalent entry point on macOS: it bypasses `test-package.ts`, selects the official Tauri driver fixture, and fails because that provider is unsupported on macOS. The CI-equivalent unit/integration suite, repository pre-push package suite, and the relevant native E2E all pass locally. CI remains responsible for the fully provisioned cross-platform fixture and provider matrix.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable)
- [x] E2E tests added/updated
- [x] Manually tested on: macOS arm64, Retina scale factor 2

Passed locally:

- `cargo test` (`17 passed`)
- `rustfmt --edition 2021 --check src/platform/executor.rs`
- `cargo clippy --all-targets -- -D warnings -A clippy::incompatible-msrv`
- `pnpm exec turbo run build --filter='./fixtures/package-tests/*'` (`27 successful`)
- `pnpm run test:unit test:integration --only --concurrency=1` (`19 successful`)
- `pnpm run test:coverage --concurrency=1` (`29 successful`)
- `TAURI_WEBDRIVER_PORT=4545 pnpm --filter @repo/e2e test:e2e:tauri-basic-embedded:window` (`14 passing`)
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck` (`28 successful`)
- repository pre-push package suite (`26 successful`)

Two strict Rust checks expose unrelated current-main/toolchain issues:

- `cargo fmt --check` with rustfmt 1.96 reports formatting drift only in untouched Rust files; the modified Rust file passes a direct rustfmt check.
- `cargo clippy --all-targets -- -D warnings` with Rust 1.96 reports existing `clippy::incompatible_msrv` warnings for `cast_unsigned` / `cast_signed` because the crate declares MSRV 1.77; allowing only that lint produces a clean clippy run.

## Screenshots/Videos

Not applicable; the regression is asserted against WebDriver rects, DOM viewport dimensions, and native Tauri physical bounds.

## Additional Context

This changes desktop behavior on macOS, Windows, and Linux because all three platforms share the same `cfg(desktop)` implementation. Mobile implementations and public endpoint shapes are unchanged. Clients that relied on the non-standard physical-pixel values will now receive W3C CSS-pixel values.

A genuine mixed-DPI multi-display transition was not available for manual testing. Scale factors 1.0, 1.25, and 2.0, negative positions, integer rounding, decoration conversion, combined move/resize, and size-only updates are covered by deterministic Rust tests and the native embedded E2E; CI provides the remaining platform matrix.

---

**Note:** This repository does not backport changes to older versions. All changes target the current `main` branch.

