### PR TITLE
test(tauri): repro coverage for #591 (embedded invoke-click wedge + external setValue)

### DIFF
--- a/e2e/test/tauri/execute-after-invoke-click.spec.ts
+++ b/e2e/test/tauri/execute-after-invoke-click.spec.ts
@@ -1,0 +1,50 @@
+import { browser, expect } from '@wdio/globals';
+import '@wdio/native-types';
+
+/**
+ * Repro for https://github.com/webdriverio/desktop-mobile/issues/591 — Bug 1.
+ *
+ * A real DOM `.click()` whose handler fires a Tauri `invoke()` (the `#invoke-button`
+ * in the fixture) is reported to permanently wedge the very next
+ * `browser.tauri.execute()` on the EMBEDDED provider — "Could not parse script
+ * result", degrading the session to "no such window".
+ *
+ * The distinction from the existing api.spec.ts coverage matters: those tests call
+ * invoke() *inside* a `browser.tauri.execute` round-trip (which resolves within the
+ * same DirectEval). This spec fires invoke() from a genuine UI click event and then
+ * issues a SEPARATE execute — the sequence nothing else in the suite exercises.
+ *
+ * Platform note: result delivery is platform-forked. macOS (wdioEvalResult message
+ * handler + per-call registry) and Windows (postMessage + AsyncScriptState) demux
+ * per call and stay healthy. Linux/WebKitGTK reads straight off
+ * `call_async_javascript_function_future` on the glib main loop it shares with wry's
+ * invoke() IPC, with no demux — so this is expected to go RED only on embedded+Linux
+ * until packages/tauri-plugin-webdriver/src/platform/linux.rs is fixed.
+ */
+describe('#591 Bug 1: execute survives an invoke()-triggering click (embedded)', () => {
+  it('baseline: DirectEval execute works before any click', async () => {
+    expect(await browser.tauri.execute(() => 1 + 1)).toBe(2);
+  });
+
+  it('CONTROL: a DOM-only click leaves execute healthy (repeatable)', async () => {
+    // #reset-button only mutates DOM state (count = 0) — no invoke().
+    const reset = await browser.$('#reset-button');
+    for (let i = 0; i < 3; i++) {
+      await reset.click();
+      expect(await browser.tauri.execute(() => 'alive')).toBe('alive');
+    }
+  });
+
+  it('REPRO: a click that fires invoke() must not wedge the next execute', async () => {
+    // Real WebDriver click → real DOM click event → handler fires Tauri invoke().
+    await (await browser.$('#invoke-button')).click();
+
+    // First script-execution command AFTER the invoke-triggering click. Per #591
+    // this is where the embedded server wedges on Linux/WebKitGTK.
+    expect(await browser.tauri.execute(() => 'alive-after-invoke-click')).toBe('alive-after-invoke-click');
+
+    // Session must remain usable; the click's invoke() should have progressed.
+    const state = await browser.tauri.execute('return window.__invokeClickState');
+    expect(['started', 'resolved']).toContain(state);
+  });
+});

--- a/e2e/test/tauri/execute-after-invoke-click.spec.ts
+++ b/e2e/test/tauri/execute-after-invoke-click.spec.ts
@@ -47,4 +47,26 @@ describe('#591 Bug 1: execute survives an invoke()-triggering click (embedded)',
     const state = await browser.tauri.execute('return window.__invokeClickState');
     expect(['started', 'resolved']).toContain(state);
   });
+
+  it('REPRO (in-flight): execute during a still-pending invoke() must not wedge', async () => {
+    // Click starts a ~2.5s slow_command invoke() that is still in-flight afterwards.
+    await (await browser.$('#invoke-slow-button')).click();
+
+    // Confirm the invoke is genuinely still pending before we poke execute. (This
+    // read is itself a DirectEval — if the in-flight invoke has already wedged the
+    // channel, this throws, which is the repro.)
+    const inflight = await browser.tauri.execute('return window.__slowInvokeState');
+    expect(inflight).toBe('in-flight');
+
+    // Hammer execute across the in-flight window — the collision the report describes.
+    for (let i = 0; i < 6; i++) {
+      expect(await browser.tauri.execute((_tauri, n) => n, i)).toBe(i);
+    }
+
+    // The session must survive until the slow invoke resolves.
+    await browser.waitUntil(
+      async () => (await browser.tauri.execute('return window.__slowInvokeState')) === 'resolved',
+      { timeout: 8000, timeoutMsg: 'slow invoke never resolved — session may be wedged' },
+    );
+  });
 });

--- a/e2e/test/tauri/set-value.linux-tripwire.spec.ts
+++ b/e2e/test/tauri/set-value.linux-tripwire.spec.ts
@@ -1,0 +1,61 @@
+// Tripwire for #591 Bug 2 — Element Send Keys under the external provider (tauri-driver
+// + native WebKitWebDriver) on Linux.
+//
+// On external + Linux, upstream tauri-driver's proxy to WebKitWebDriver drops the W3C
+// `text` field on POST /element/{id}/value, so setValue()/addValue()/clearValue() fail
+// with "Missing text parameter". @wdio/tauri-service is a pure orchestrator here and
+// never touches that body (our own embedded driver handles `text` correctly — see
+// set-value.spec.ts). The positive spec therefore skips this cell; this spec is the
+// inverse: it runs ONLY on external + Linux and asserts setValue STILL fails. While the
+// upstream bug is open it passes; the moment setValue succeeds it fails — the signal to
+// remove this tripwire, drop the external+Linux skip in set-value.spec.ts, and update #591.
+//
+// Scoping: WebKitWebDriver-specific. The external provider off Linux (Windows/WebView2)
+// is unaffected, so the inverse assertion would false-fire there — hence the guard below
+// and the config exclusion outside external+Linux.
+import { browser } from '@wdio/globals';
+import '@wdio/native-types';
+import process from 'node:process';
+
+const isExternalLinux = process.platform === 'linux' && process.env.DRIVER_PROVIDER === 'external';
+const MISSING_TEXT = /Missing text parameter/i;
+
+describe('#591 Bug 2 setValue tripwire (upstream tauri-driver)', () => {
+  it('setValue should STILL fail with "Missing text parameter" on external+Linux (fails when upstream is fixed)', async function () {
+    if (!isExternalLinux) {
+      this.skip();
+    }
+
+    await browser.execute(() => {
+      // @ts-expect-error document is a browser-context global
+      const el = document.getElementById('repro-input');
+      if (el) {
+        el.value = '';
+      }
+    });
+
+    const input = await browser.$('#repro-input');
+
+    let failedWithMissingText = false;
+    try {
+      await input.setValue('hello');
+    } catch (err) {
+      // Only the specific "Missing text parameter" failure is the healthy state while the
+      // upstream bug is open. Any other error (session crash, I/O, …) is a real failure —
+      // re-throw so it can't masquerade as a green tripwire.
+      if (err instanceof Error && MISSING_TEXT.test(err.message)) {
+        failedWithMissingText = true;
+      } else {
+        throw err;
+      }
+    }
+
+    if (!failedWithMissingText) {
+      throw new Error(
+        'setValue() no longer fails with "Missing text parameter" on external tauri-driver + ' +
+          'WebKitWebDriver — the upstream bug looks fixed. Remove this tripwire, drop the ' +
+          'external+Linux skip in set-value.spec.ts, and update #591.',
+      );
+    }
+  });
+});

--- a/e2e/test/tauri/set-value.spec.ts
+++ b/e2e/test/tauri/set-value.spec.ts
@@ -1,0 +1,65 @@
+import { browser, expect } from '@wdio/globals';
+import '@wdio/native-types';
+import process from 'node:process';
+
+/**
+ * Positive coverage for Element Send Keys (setValue / addValue / clearValue) against
+ * the fixture's `#repro-input`. Motivated by issue #591 Bug 2.
+ *
+ * All three route through POST /session/{id}/element/{id}/value with a W3C `{ text }`
+ * body. This passes on the embedded provider (our own W3C-correct send_keys handler)
+ * on every platform, and on the external provider off the WebKitWebDriver path
+ * (e.g. Windows/WebView2).
+ *
+ * The external + Linux cell is known-broken UPSTREAM: tauri-driver's proxy to
+ * WebKitWebDriver drops `text` ("Missing text parameter"). That cell is asserted
+ * instead by set-value.linux-tripwire.spec.ts, so it is skipped here to keep the
+ * green suite green.
+ */
+const isExternalLinux = process.env.DRIVER_PROVIDER === 'external' && process.platform === 'linux';
+
+async function resetInput() {
+  await browser.execute(() => {
+    // @ts-expect-error document is a browser-context global
+    const el = document.getElementById('repro-input');
+    if (el) {
+      el.value = '';
+    }
+  });
+}
+
+describe('#591 Bug 2: Element Send Keys', () => {
+  beforeEach(async function () {
+    if (isExternalLinux) {
+      this.skip();
+    }
+    await resetInput();
+  });
+
+  it('setValue() types into a text input', async () => {
+    const input = await browser.$('#repro-input');
+    await input.setValue('hello');
+    await expect(input).toHaveValue('hello');
+  });
+
+  it('addValue() appends to a text input', async () => {
+    const input = await browser.$('#repro-input');
+    await input.setValue('foo');
+    await input.addValue('bar');
+    await expect(input).toHaveValue('foobar');
+  });
+
+  it('clearValue() empties a text input', async () => {
+    const input = await browser.$('#repro-input');
+    await input.setValue('to-be-cleared');
+    await input.clearValue();
+    await expect(input).toHaveValue('');
+  });
+
+  it('WORKAROUND: browser.keys() (Actions API) types into the same input', async () => {
+    const input = await browser.$('#repro-input');
+    await input.click();
+    await browser.keys('hello'.split(''));
+    await expect(input).toHaveValue('hello');
+  });
+});

--- a/e2e/wdio.tauri-embedded.conf.ts
+++ b/e2e/wdio.tauri-embedded.conf.ts
@@ -118,6 +118,9 @@ switch (envContext.testType) {
       './test/tauri/window.spec.ts',
       './test/tauri/deeplink.spec.ts',
       './test/tauri/logging.tauri-driver.spec.ts',
+      // #591 Bug 2 tripwire asserts the upstream external+Linux failure; on the
+      // embedded provider setValue works, so its inverse assertion would false-fire.
+      './test/tauri/set-value.linux-tripwire.spec.ts',
     ];
     // Note: logging.embedded.spec.ts is included to document the limitation
     break;

--- a/e2e/wdio.tauri.conf.ts
+++ b/e2e/wdio.tauri.conf.ts
@@ -137,6 +137,11 @@ if (envContext.driverProvider === 'crabnebula') {
 if (process.platform !== 'darwin' || envContext.driverProvider !== 'crabnebula') {
   exclude.push('./test/tauri/logging.crabnebula-tripwire.spec.ts');
 }
+// #591 Bug 2 is upstream tauri-driver dropping `text` only on the WebKitWebDriver (Linux) path.
+// Run its inverse assertion only on external+Linux; elsewhere setValue works and it would false-fire.
+if (process.platform !== 'linux' || envContext.driverProvider !== 'external') {
+  exclude.push('./test/tauri/set-value.linux-tripwire.spec.ts');
+}
 
 // Configure capabilities
 type TauriCapability = {

--- a/fixtures/e2e-apps/tauri/Cargo.lock
+++ b/fixtures/e2e-apps/tauri/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-wdio",
  "tauri-plugin-wdio-webdriver",
+ "tokio",
 ]
 
 [[package]]
@@ -3951,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-wdio-webdriver"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/fixtures/e2e-apps/tauri/index.html
+++ b/fixtures/e2e-apps/tauri/index.html
@@ -101,6 +101,7 @@
       <div class="repro-section">
         <input type="text" id="repro-input" aria-label="Repro input" placeholder="type here" />
         <button type="button" id="invoke-button">Invoke (get_platform_info)</button>
+        <button type="button" id="invoke-slow-button">Invoke slow (in-flight)</button>
         <div class="status" id="invoke-status">idle</div>
       </div>
     </div>
@@ -234,6 +235,28 @@
           .catch((error) => {
             window.__invokeClickState = `rejected:${String(error)}`;
             invokeStatusElement.textContent = 'rejected';
+          });
+      });
+
+      // In-flight variant: fires a deliberately slow invoke() so the app IPC
+      // channel is still busy when the next WebDriver execute() runs (#591 Bug 1).
+      const invokeSlowButton = document.getElementById('invoke-slow-button');
+      window.__slowInvokeState = 'idle';
+      invokeSlowButton.addEventListener('click', () => {
+        window.__slowInvokeState = 'in-flight';
+        invokeStatusElement.textContent = 'slow-in-flight';
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (!invoke) {
+          window.__slowInvokeState = 'rejected:no-invoke';
+          return;
+        }
+        invoke('slow_command', { ms: 2500 })
+          .then(() => {
+            window.__slowInvokeState = 'resolved';
+            invokeStatusElement.textContent = 'slow-resolved';
+          })
+          .catch((error) => {
+            window.__slowInvokeState = `rejected:${String(error)}`;
           });
       });
 

--- a/fixtures/e2e-apps/tauri/index.html
+++ b/fixtures/e2e-apps/tauri/index.html
@@ -96,6 +96,13 @@
         <div class="status" id="status">Ready for testing</div>
         <button type="button" id="switch-main-window" class="switch-main-window" style="display:none">Continue to Main</button>
       </div>
+
+      <!-- Repro surface for issue #591 (do not remove without updating the #591 specs). -->
+      <div class="repro-section">
+        <input type="text" id="repro-input" aria-label="Repro input" placeholder="type here" />
+        <button type="button" id="invoke-button">Invoke (get_platform_info)</button>
+        <div class="status" id="invoke-status">idle</div>
+      </div>
     </div>
 
     <script type="module">
@@ -201,6 +208,33 @@
       resetButton.addEventListener('click', () => {
         count = 0;
         updateCounter();
+      });
+
+      // Repro surface for issue #591 — a real DOM click handler that fires a
+      // Tauri invoke(). Records progress on window so specs can observe it. The
+      // invoke here is UI-initiated (not via browser.tauri.execute), which is the
+      // exact trigger for the embedded-provider wedge reported in #591.
+      const invokeButton = document.getElementById('invoke-button');
+      const invokeStatusElement = document.getElementById('invoke-status');
+      window.__invokeClickState = 'idle';
+      invokeButton.addEventListener('click', () => {
+        window.__invokeClickState = 'started';
+        invokeStatusElement.textContent = 'started';
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (!invoke) {
+          window.__invokeClickState = 'rejected:no-invoke';
+          invokeStatusElement.textContent = 'rejected:no-invoke';
+          return;
+        }
+        invoke('get_platform_info')
+          .then(() => {
+            window.__invokeClickState = 'resolved';
+            invokeStatusElement.textContent = 'resolved';
+          })
+          .catch((error) => {
+            window.__invokeClickState = `rejected:${String(error)}`;
+            invokeStatusElement.textContent = 'rejected';
+          });
       });
 
       // Initialize

--- a/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
+++ b/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 sysinfo = "0.30.5"
 clipboard = "0.5.0"
 once_cell = "1.19"
+tokio = { version = "1", features = ["time"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
+++ b/fixtures/e2e-apps/tauri/src-tauri/src/main.rs
@@ -263,6 +263,14 @@ async fn switch_to_main(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+// Deliberately slow command so a UI-initiated invoke() stays in-flight while a
+// subsequent WebDriver script-execution command runs — the #591 Bug 1 trigger.
+#[tauri::command]
+async fn slow_command(ms: Option<u64>) -> Result<String, String> {
+    tokio::time::sleep(std::time::Duration::from_millis(ms.unwrap_or(2500))).await;
+    Ok("slow-done".to_string())
+}
+
 fn main() {
     let is_splash = std::env::var("ENABLE_SPLASH_WINDOW").is_ok();
 
@@ -388,6 +396,7 @@ fn main() {
             switch_to_main,
             get_deep_links,
             get_command_line_args,
+            slow_command,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
Draft / **verify-only** — pushed to run the full Tauri E2E matrix and confirm the two bugs in #591 across platforms. Not for merge as-is (see caveats).

## Why the existing (green) Tauri E2Es miss both bugs
The fixture `fixtures/e2e-apps/tauri/index.html` had **no text `<input>` and no invoke-wired button** — the counter buttons are DOM-only. And every `invoke()` in the suite runs *inside* a `browser.tauri.execute` round-trip (resolves within the same DirectEval). Nothing did the reporter's sequences: real `.click()` → handler `invoke()` → *separate* `execute`, or `setValue()` on a text input.

## What this adds
**Fixture** (`index.html`): a real `#repro-input` and a `#invoke-button` whose click handler fires a UI-initiated `invoke('get_platform_info')`.

**Bug 1 — `execute-after-invoke-click.spec.ts`** (embedded): baseline + a DOM-only control arm + the repro (click `#invoke-button`, then a separate `browser.tauri.execute`).
- Result delivery is platform-forked. macOS (`wdioEvalResult` message handler + per-call `EvalResultRegistry`) and Windows (`postMessage` + `AsyncScriptState`) demux per call and stay healthy — **verified green locally on macOS**.
- Linux/WebKitGTK reads straight off `call_async_javascript_function_future` on the glib main loop it shares with wry's `invoke()` IPC, **with no demux** (`packages/tauri-plugin-webdriver/src/platform/linux.rs`). Expected **RED on embedded+Linux** — that's the reproduction.

**Bug 2 — `set-value.spec.ts`** (positive) + **`set-value.linux-tripwire.spec.ts`** (inverse):
- `@wdio/tauri-service` is a pure orchestrator on the external path and never touches the send-keys body (`addValue` isn't even overridden yet fails identically per the report). Our **own embedded driver's `send_keys` is W3C-`text`-correct** — the positive spec is **verified green locally on macOS embedded**.
- The external + Linux cell is broken **upstream** in `tauri-driver 2.0.6` ↔ `WebKitWebDriver 2.52.3` (drops the W3C `text` field → `Missing text parameter`; `browser.keys()`/Actions works). The positive spec skips that one cell; the tripwire asserts the failure inversely — green while upstream is broken, **flips red when upstream ships a fix**. Wiring mirrors the #179 crabnebula tripwire.

## What the matrix should tell us
- **Bug 1**: is it embedded+Linux-only, or does embedded+Windows trip too? (Expect Windows green.)
- **Bug 2**: is `Missing text parameter` WebKitWebDriver-specific, or all external? External+Windows uses msedgedriver/WebView2 — if green there, it's confirmed WebKitGTK/upstream-specific and belongs on `tauri-apps/tauri`.

## Merge caveats (why draft)
- **Bug 1** is ours to fix in `linux.rs`; its spec should stay red on embedded+Linux until then. Either fix in a follow-up and merge green, or land fixture-only + gate the spec as a tracked known-failure.
- **Bug 2** positive + tripwire are designed to be **green across the whole matrix** and can land once the matrix confirms the external+Windows-green / external+Linux-red split. File/point the tripwire at a `tauri-apps/tauri` upstream issue.

Refs #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)