### PR TITLE
fix(tauri): adopt CrabNebula macOS-26.4 session fix (tauri-plugin-automation 0.1.4 + test-runner-backend 0.2.9)

### DIFF
--- a/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-tauri-all-providers.reusable.yml
@@ -557,16 +557,12 @@ jobs:
           #  - Windows: WebView2 Runtime 150 dropped the CDP --remote-debugging-port for
           #    elevated hosts (runners run as admin), breaking the msedgedriver-based
           #    official + crabnebula providers. See https://github.com/webdriverio/desktop-mobile/issues/542.
-          #  - macOS: the macos-26 image (26.4) broke the closed-source CrabNebula
-          #    driver's session setup. See https://github.com/webdriverio/desktop-mobile/issues/540.
           allow_official=false; official_reason=""
           allow_crabnebula=false; crabnebula_reason=""
           case "$RUNNER_OS" in
             Windows)
               allow_official=true;   official_reason="WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542"
               allow_crabnebula=true; crabnebula_reason="WebView2 150 elevated-host regression; see https://github.com/webdriverio/desktop-mobile/issues/542" ;;
-            macOS)
-              allow_crabnebula=true; crabnebula_reason="macos-26 image (26.4) broke the CrabNebula driver; see https://github.com/webdriverio/desktop-mobile/issues/540" ;;
           esac
 
           check_result "Official" "$official" "$allow_official" "$official_reason"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@crabnebula/tauri-driver": "^2.0.9",
-    "@crabnebula/test-runner-backend": "^0.2.8",
+    "@crabnebula/test-runner-backend": "^0.2.9",
     "@electron-forge/cli": "catalog:default",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.2",

--- a/fixtures/e2e-apps/tauri/Cargo.lock
+++ b/fixtures/e2e-apps/tauri/Cargo.lock
@@ -3860,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-automation"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9183fa70494162bb1571998a9f578eeda96dd92d3431082165f38bff647f3311"
+checksum = "314d4ba88ce4a5e17c5f1e2dad990edb5956643b6e04a6d127d39aa64d0f2a7d"
 dependencies = [
  "libloading 0.8.9",
  "objc2-app-kit",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-wdio-webdriver"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
+++ b/fixtures/e2e-apps/tauri/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-wdio = { path = "../../../../packages/tauri-plugin" }
 tauri-plugin-wdio-webdriver = { path = "../../../../packages/tauri-plugin-webdriver" }
-tauri-plugin-automation = "0.1"
+tauri-plugin-automation = "0.1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = "0.30.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^2.0.9
         version: 2.0.9
       '@crabnebula/test-runner-backend':
-        specifier: ^0.2.8
-        version: 0.2.8
+        specifier: ^0.2.9
+        version: 0.2.9
       '@electron-forge/cli':
         specifier: catalog:default
         version: 7.11.2(encoding@0.1.13)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(supports-color@8.1.1)(uglify-js@3.19.3)
@@ -1876,33 +1876,33 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@crabnebula/test-runner-backend-darwin-arm64@0.2.8':
-    resolution: {integrity: sha512-2FWWOdKHLP8fdkleQ104fggZnZei7bmXzg8Xw1mi/3QbCRWuzWYwMrGFW7PZRwgGfsqJ4HpT1H3oEyQLkAzvJg==}
+  '@crabnebula/test-runner-backend-darwin-arm64@0.2.9':
+    resolution: {integrity: sha512-UAlL8VA23y/fp+MigNYFwGvtE9vJ518f846c0k2vgT/bLIpt+d3UXndjZCMYbEVFTmaq00wHoRPSPbyzHEMWlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@crabnebula/test-runner-backend-darwin-x64@0.2.8':
-    resolution: {integrity: sha512-L7reGnRY8gVbUlvj4PF/xBK+NeFXgpcFu5iSJIWbjwV3+DTjHj6iXpGi68y7MjYpcyHvxwjKmqNrjriE04FA1g==}
+  '@crabnebula/test-runner-backend-darwin-x64@0.2.9':
+    resolution: {integrity: sha512-RUP9L4Lk8KsT4A64U4QFVy5rj99Y6iIichPLpZgTvpRybYKZBVXjUiU31aGUIlWnd4VHsWKLM2vNl90rKZm3lA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@crabnebula/test-runner-backend-linux-x64-gnu@0.2.8':
-    resolution: {integrity: sha512-eGFBs66Zxy4xVhLubH4IEht0RMK/AJHLEcCP4q+Mvmt1FiqegTj2SZTnC0OoAY56XPC7ns3We2hrYg2gS4K4ag==}
+  '@crabnebula/test-runner-backend-linux-x64-gnu@0.2.9':
+    resolution: {integrity: sha512-js/haLE9OUsa0oDHNuVps5DY7av3iWG7PpAKjr9nMnIEXiLACDmvyUL/IplHMmu1lr6S0fztoudRf4JfTR+mfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@crabnebula/test-runner-backend-win32-x64-msvc@0.2.8':
-    resolution: {integrity: sha512-nsrg7V8qjRF1qDk8Lw/gkNrmyt2SjksF6wzSAmgObjWzoy3VHNNCwUtpWl4RVNI6/NzpGVxkZ7L+Jgk2EoAqOg==}
+  '@crabnebula/test-runner-backend-win32-x64-msvc@0.2.9':
+    resolution: {integrity: sha512-p4pc/GQ0bj3vVLuUyTHDnhaXO52EQNkaCUPhWXwEkG00loW93pvCBRrOWoYpJH9me/n2zMFv61meW9mQyvbByw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@crabnebula/test-runner-backend@0.2.8':
-    resolution: {integrity: sha512-dxdJ4zbpBwuEdo5V5pIICtPqlh+x2Xv+Va+u+ImvgjcZpk8inlSF9LxzZYI/soSmw3FBLHK5yVrqhc1+FS3MzA==}
+  '@crabnebula/test-runner-backend@0.2.9':
+    resolution: {integrity: sha512-3z6qZbJtVyA1JymQU5hFqcxG6nFD5INgqBc3OxTbYXVzMpihlRGOcHWyPK72ndHK88YmfwQWPcEFN1R/H/Lvhw==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -2046,7 +2046,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -9018,24 +9018,24 @@ snapshots:
       '@crabnebula/tauri-driver-linux-x64-gnu': 2.0.9
       '@crabnebula/tauri-driver-win32-x64-msvc': 2.0.9
 
-  '@crabnebula/test-runner-backend-darwin-arm64@0.2.8':
+  '@crabnebula/test-runner-backend-darwin-arm64@0.2.9':
     optional: true
 
-  '@crabnebula/test-runner-backend-darwin-x64@0.2.8':
+  '@crabnebula/test-runner-backend-darwin-x64@0.2.9':
     optional: true
 
-  '@crabnebula/test-runner-backend-linux-x64-gnu@0.2.8':
+  '@crabnebula/test-runner-backend-linux-x64-gnu@0.2.9':
     optional: true
 
-  '@crabnebula/test-runner-backend-win32-x64-msvc@0.2.8':
+  '@crabnebula/test-runner-backend-win32-x64-msvc@0.2.9':
     optional: true
 
-  '@crabnebula/test-runner-backend@0.2.8':
+  '@crabnebula/test-runner-backend@0.2.9':
     optionalDependencies:
-      '@crabnebula/test-runner-backend-darwin-arm64': 0.2.8
-      '@crabnebula/test-runner-backend-darwin-x64': 0.2.8
-      '@crabnebula/test-runner-backend-linux-x64-gnu': 0.2.8
-      '@crabnebula/test-runner-backend-win32-x64-msvc': 0.2.8
+      '@crabnebula/test-runner-backend-darwin-arm64': 0.2.9
+      '@crabnebula/test-runner-backend-darwin-x64': 0.2.9
+      '@crabnebula/test-runner-backend-linux-x64-gnu': 0.2.9
+      '@crabnebula/test-runner-backend-win32-x64-msvc': 0.2.9
 
   '@csstools/color-helpers@6.1.0': {}
 


### PR DESCRIPTION
Confirmed fix for **#541** (CrabNebula can't create sessions on the `macos-26-arm64` 26.4 runner). Bumping **`tauri-plugin-automation` → 0.1.4** and **`@crabnebula/test-runner-backend` → 0.2.9** (per the CrabNebula maintainer) takes the CrabNebula provider from **0 passed / 8 failed → 8 passed / 8 total**, with no more `failed to send request`.

This matches our trace-level diagnosis of #541: session creation succeeds, but the first command (`GET /window`) fails with a remote-side `failed to send request` — and `tauri-plugin-automation` is that "remote" (the app-side WKWebView automation endpoint the CrabNebula backend forwards to). A fix there explains the timeout resolution.

## Change
- `tauri-plugin-automation` `0.1` → **`0.1.4`** (fixture `Cargo.toml` + `Cargo.lock`)
- `@crabnebula/test-runner-backend` `^0.2.8` → **`^0.2.9`** (`e2e/package.json` + `pnpm-lock.yaml`)
- `@crabnebula/tauri-driver` stays `2.0.9` (unchanged, per the maintainer).

## CI result (macos-26-arm64)
All five **E2E - Tauri [macOS-ARM]** cells green; the `standard` cell's CrabNebula provider is **8/8** (was `0/8`).

## To adopt (still draft)
- Remove the macOS CrabNebula allow-fail in `_ci-e2e-tauri-all-providers.reusable.yml` so the provider is **required** again (it's green now).
- `Closes #541`.

## Note on #179 (logging) — *not* fixed here
With sessions working, the #179 logging tripwire now *runs* and correctly stays **green**: app backend logs still don't reach the test on CrabNebula/macOS, because the `.app` bundle's stderr is detached and every app-side log path funnels through it. That's a CrabNebula-side matter (raised upstream) — **#179 stays open**, and this PR neither fixes nor destabilizes it.

Refs #541
