### PR TITLE
fix(flutter): pin package-test to appium-flutter-driver 3.9.1 (broken finder 0.3.0)

### DIFF
--- a/fixtures/package-tests/flutter-app/package.json
+++ b/fixtures/package-tests/flutter-app/package.json
@@ -19,7 +19,7 @@
     "@wdio/native-types": "workspace:*",
     "@wdio/spec-reporter": "^9.30.1",
     "appium": "^3.6.0",
-    "appium-flutter-driver": "^3.9.1",
+    "appium-flutter-driver": "3.9.1",
     "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,7 +750,7 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       appium-flutter-driver:
-        specifier: ^3.9.1
+        specifier: 3.9.1
         version: 3.9.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       typescript:
         specifier: ^6.0.3


### PR DESCRIPTION
## Problem
All Flutter E2E is failing everywhere (every PR/branch, no recovery on retry) with:

```
Could not find a driver for automationName 'Flutter' and platformName 'Android'|iOS
  (Lower-level error: No "exports" main defined in …/appium-flutter-driver@3.10.0/…/appium-flutter-finder)
✖ Failed to create a session
```

## Root cause
- `appium-flutter-driver@3.10.0` requires `appium-flutter-finder@^0.3.0`.
- `appium-flutter-finder@0.3.0` (just released) added a **malformed `exports`** field — Node then ignores `main` and finds no valid entry → `No "exports" main defined` → the driver module can't load → it never registers → every Flutter session fails.
- Deterministic (not a flake), which is why it's everywhere and never clears on retry.

The **monorepo e2e** is protected by the committed frozen lockfile (`driver 3.9.1` + `finder 0.2.3`). The break is the **package-test fixture**, which does an isolated fresh install — the `^3.9.1` caret resolved up to the broken `3.10.0`.

## Fix
Pin `fixtures/package-tests/flutter-app/package.json` to **exact `3.9.1`**. Its `appium-flutter-finder@^0.2.0` range resolves `0.2.3` (no `exports` field), so it can't reach the broken `0.3.0`.

Revert once upstream ships a valid `appium-flutter-finder` `0.3.x` (tracking issue + upstream report to follow).