### PR TITLE
fix(native-types): model appium:* tuning keys on ReactNativeCapabilities (#574)

### DIFF
--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -2,7 +2,7 @@ import { appendFileSync, existsSync, globSync, mkdirSync, statSync } from 'node:
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { ReactNativeServiceOptions } from '@wdio/native-types';
+import type { ReactNativeCapabilities, ReactNativeServiceOptions } from '@wdio/native-types';
 
 import { getLogDirName } from './lib/utils.js';
 
@@ -105,27 +105,7 @@ const reactNativeServiceOptions: ReactNativeServiceOptions = {
   doctor: { strict: true },
 };
 
-// Local superset of the shipped `ReactNativeCapabilities`, which does not model the iOS/WDA
-// tuning keys below. Duplicated in fixtures/package-tests/react-native-app/wdio.conf.ts;
-// drop both once #574 lands.
-type ReactNativeCapability = {
-  platformName: 'Android' | 'iOS';
-  'appium:automationName': 'UiAutomator2' | 'XCUITest';
-  'appium:app': string;
-  'appium:newCommandTimeout': number;
-  'appium:deviceName'?: string;
-  'appium:udid'?: string;
-  'appium:wdaLaunchTimeout'?: number;
-  'appium:simulatorStartupTimeout'?: number;
-  'appium:usePreinstalledWDA'?: boolean;
-  'appium:prebuiltWDAPath'?: string;
-  'appium:wdaStartupRetries'?: number;
-  'appium:wdaStartupRetryInterval'?: number;
-  'appium:isHeadless'?: boolean;
-  'wdio:reactNativeServiceOptions': ReactNativeServiceOptions;
-};
-
-const capabilities: ReactNativeCapability[] = [
+const capabilities: ReactNativeCapabilities[] = [
   {
     platformName: isIos ? 'iOS' : 'Android',
     'appium:automationName': isIos ? 'XCUITest' : 'UiAutomator2',

--- a/fixtures/package-tests/react-native-app/wdio.conf.ts
+++ b/fixtures/package-tests/react-native-app/wdio.conf.ts
@@ -1,27 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { ReactNativeServiceOptions } from '@wdio/native-types';
-
-// Local superset of the shipped `ReactNativeCapabilities`, which does not yet model the
-// iOS/WDA tuning keys this config sets. Mirrors the same workaround in
-// e2e/wdio.react-native.conf.ts; drop both once #574 lands.
-type ReactNativeCapability = {
-  platformName: 'Android' | 'iOS';
-  'appium:automationName': 'UiAutomator2' | 'XCUITest';
-  'appium:app': string;
-  'appium:deviceName'?: string;
-  'appium:platformVersion'?: string;
-  'appium:noReset'?: boolean;
-  'appium:udid'?: string;
-  'appium:wdaLaunchTimeout'?: number;
-  'appium:simulatorStartupTimeout'?: number;
-  'appium:usePreinstalledWDA'?: boolean;
-  'appium:prebuiltWDAPath'?: string;
-  'appium:wdaStartupRetries'?: number;
-  'appium:wdaStartupRetryInterval'?: number;
-  'wdio:reactNativeServiceOptions': ReactNativeServiceOptions;
-};
+import type { ReactNativeCapabilities, ReactNativeServiceOptions } from '@wdio/native-types';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -59,7 +39,7 @@ const rnServiceOptions: ReactNativeServiceOptions = {
   doctor: false,
 };
 
-const capabilities: ReactNativeCapability[] = [
+const capabilities: ReactNativeCapabilities[] = [
   platform === 'ios'
     ? {
         platformName: 'iOS',

--- a/packages/native-types/src/flutter.ts
+++ b/packages/native-types/src/flutter.ts
@@ -229,6 +229,12 @@ export interface FlutterCapabilities {
   'appium:bundleId'?: string;
   /** Pin the Dart VM Service port (deterministic discovery; iOS-friendly). */
   'appium:dartVmServicePort'?: number;
+  /**
+   * Arbitrary Appium tuning keys (WDA/simulator timeouts, `appium:isHeadless`, …).
+   * Modelled generically so real configs don't need a local superset of this type —
+   * the keys above stay strictly typed.
+   */
+  [key: `appium:${string}`]: unknown;
   'wdio:flutterServiceOptions'?: FlutterServiceOptions;
 }
 

--- a/packages/native-types/src/react-native.ts
+++ b/packages/native-types/src/react-native.ts
@@ -118,7 +118,7 @@ export interface ReactNativeServiceAPI {
    *
    * @example
    * ```js
-   * const isHermes = await browser.reactNative.execute(() => typeof HermesInternal === 'object');
+   * const isHermes = await browser.reactNative.execute((rn) => typeof rn.HermesInternal === 'object');
    * ```
    */
   execute<ReturnValue, InnerArguments extends unknown[]>(
@@ -362,6 +362,12 @@ export interface ReactNativeCapabilities {
   'appium:appActivity'?: string;
   /** iOS: launch by bundle id instead of an app path. */
   'appium:bundleId'?: string;
+  /**
+   * Arbitrary Appium tuning keys (WDA/simulator timeouts, `appium:newCommandTimeout`,
+   * `appium:isHeadless`, …). Modelled generically so real configs don't need a local
+   * superset of this type — the keys above stay strictly typed.
+   */
+  [key: `appium:${string}`]: unknown;
   'wdio:reactNativeServiceOptions'?: ReactNativeServiceOptions;
 }
 

--- a/packages/react-native-service/README.md
+++ b/packages/react-native-service/README.md
@@ -59,7 +59,7 @@ export const config = {
 ```ts
 // a spec
 it('should run code in the Hermes realm', async () => {
-  const inHermes = await browser.reactNative.execute(() => typeof HermesInternal !== 'undefined');
+  const inHermes = await browser.reactNative.execute((rn) => typeof rn.HermesInternal !== 'undefined');
   expect(inHermes).toBe(true);
 });
 


### PR DESCRIPTION
## Problem

`ReactNativeCapabilities` modelled only a fixed set of `appium:*` keys, so a config literal that set the WDA/simulator tuning keys real setups need failed with `TS2322: … 'appium:simulatorStartupTimeout' does not exist in type 'ReactNativeCapabilities'`. Both in-repo RN configs (`e2e/wdio.react-native.conf.ts` and the `react-native-app` package-test fixture, since #573 began typechecking it) worked around this by declaring an identical local `ReactNativeCapability` superset — the two copies were the signal that the shipped type was wrong.

## Fix

- Add an `[key: \`appium:${string}\`]: unknown` index signature to `ReactNativeCapabilities` **and** `FlutterCapabilities` (which had the same hole). The explicitly-modelled keys keep their strict types; only arbitrary `appium:*` tuning keys become permissible.
- Delete both duplicated local supersets and use the shipped `ReactNativeCapabilities` directly.
- Doc nit called out in the issue: the second `execute` JSDoc example (`native-types`) and `react-native-service/README.md` both used the bare `HermesInternal` global, which doesn't typecheck — switched to the typed `(rn) => … rn.HermesInternal` form the primary example uses.

## Verification

- `@wdio/native-types` builds; `@wdio/react-native-service` + `@wdio/flutter-service` typecheck.
- `react-native-app` fixture (`tsc --noEmit`) is green using the shipped type.
- `format:check` + biome lint clean.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
