### PR TITLE
test(flutter): exercise iOS boot-cap defaults on the Flutter-iOS leg (#428)

### DIFF
--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -118,9 +118,8 @@ const capabilities: FlutterCapability[] = [
           // Omitted locally (appium resolves by name).
           ...(process.env.FLUTTER_IOS_UDID ? { 'appium:udid': process.env.FLUTTER_IOS_UDID } : {}),
           // wdaLaunchTimeout + simulatorStartupTimeout are intentionally omitted so
-          // native-mobile-core's applyBootCapDefaults (720000 / 240000, apply-if-unset) is
-          // exercised end-to-end on this leg (#428) instead of only in unit tests. The generous
-          // default wdaLaunchTimeout replaces the prior FLUTTER_WDA_DD-conditional 120000 ceiling.
+          // native-mobile-core's applyBootCapDefaults (apply-if-unset) is exercised
+          // end-to-end on this leg (#428), not just in unit tests.
           // WDA on GitHub-Actions sims often fails to come up on the first attempt (ECONNREFUSED
           // 8100 / session-create timeout). appium's default is only 2 startup retries — bump it.
           'appium:wdaStartupRetries': 5,

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -109,8 +109,7 @@ const capabilities: FlutterCapability[] = [
     // iOS: appium-flutter-driver wraps appium-xcuitest, which launches WebDriverAgent. CI
     // pre-builds WDA into FLUTTER_WDA_DD; reuse it (usePreinstalledWDA — simctl install/launch) so
     // the first session just launches it — fast, no per-session xcodebuild (which under WDIO's
-    // undici client dropped the POST /session socket on the RN leg). Generous sim-boot ceiling for
-    // cold/slow runners.
+    // undici client dropped the POST /session socket on the RN leg).
     ...(isIos
       ? {
           'appium:deviceName': process.env.FLUTTER_IOS_DEVICE ?? 'iPhone 17',
@@ -118,11 +117,10 @@ const capabilities: FlutterCapability[] = [
           // so appium doesn't independently resolve the deviceName to a different instance (#359).
           // Omitted locally (appium resolves by name).
           ...(process.env.FLUTTER_IOS_UDID ? { 'appium:udid': process.env.FLUTTER_IOS_UDID } : {}),
-          'appium:simulatorStartupTimeout': 240000,
-          // Prebuilt WDA just launches (no compile), so a tight per-attempt ceiling lets several
-          // startup retries fit inside connectionRetryTimeout below; non-prebuilt (local) must
-          // allow the multi-minute compile.
-          'appium:wdaLaunchTimeout': process.env.FLUTTER_WDA_DD ? 120000 : 720000,
+          // wdaLaunchTimeout + simulatorStartupTimeout are intentionally omitted so
+          // native-mobile-core's applyBootCapDefaults (720000 / 240000, apply-if-unset) is
+          // exercised end-to-end on this leg (#428) instead of only in unit tests. The generous
+          // default wdaLaunchTimeout replaces the prior FLUTTER_WDA_DD-conditional 120000 ceiling.
           // WDA on GitHub-Actions sims often fails to come up on the first attempt (ECONNREFUSED
           // 8100 / session-create timeout). appium's default is only 2 startup retries — bump it.
           'appium:wdaStartupRetries': 5,

--- a/e2e/wdio.flutter.conf.ts
+++ b/e2e/wdio.flutter.conf.ts
@@ -118,8 +118,8 @@ const capabilities: FlutterCapability[] = [
           // Omitted locally (appium resolves by name).
           ...(process.env.FLUTTER_IOS_UDID ? { 'appium:udid': process.env.FLUTTER_IOS_UDID } : {}),
           // wdaLaunchTimeout + simulatorStartupTimeout are intentionally omitted so
-          // native-mobile-core's applyBootCapDefaults (apply-if-unset) is exercised
-          // end-to-end on this leg (#428), not just in unit tests.
+          // native-mobile-core's applyBootCapDefaults actually fills them in.
+          // https://github.com/webdriverio/desktop-mobile/issues/428
           // WDA on GitHub-Actions sims often fails to come up on the first attempt (ECONNREFUSED
           // 8100 / session-create timeout). appium's default is only 2 startup retries — bump it.
           'appium:wdaStartupRetries': 5,


### PR DESCRIPTION
## What

Drops the explicit `appium:wdaLaunchTimeout` + `appium:simulatorStartupTimeout` from the **Flutter iOS** e2e capability so `native-mobile-core`'s `applyBootCapDefaults` (720000 / 240000, apply-if-unset, invoked by `MobileBaseLauncher`) is exercised **end-to-end** — today those defaults only have unit coverage because every e2e config pins the values by hand.

Per #428, this trials **one platform first** (Flutter-iOS) rather than doing RN-iOS + Flutter-iOS together, because the flat default `wdaLaunchTimeout: 720000` is more generous than the prior `FLUTTER_WDA_DD ? 120000 : 720000` ceiling and could mask a slow first session — worth a single-leg CI signal before extending.

## Kept (as the issue calls out)

- **`appium:udid`** — the exact pre-booted sim pin (dropping it reintroduces the #359 "booted a different sim" flake).
- **`appium:wdaStartupRetries` / `wdaStartupRetryInterval`** and the **prebuilt-WDA reuse** (`usePreinstalledWDA` + `prebuiltWDAPath`) — `applyBootCapDefaults` only sets timeouts/headless, so these must stay explicit.

## Verification

- `format:check` + `@wdio/flutter-service` typecheck pass. The real signal is this PR's **Flutter [iOS]** e2e leg going green with the defaults applied.

Refs #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
