### PR TITLE
fix(tauri): retain top-level WebView executors after child mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Preserve embedded Tauri WebDriver access to a top-level window after the app adds a child webview.
 
 ## [@wdio/dioxus-bridge@1.0.0] - 2026-08-05
 

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -44,6 +44,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 #[must_use]
 pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
     let windows = std::sync::Arc::new(server::WindowRegistry::new());
+    let ready_windows = std::sync::Arc::clone(&windows);
     let server_start = std::sync::Arc::new(std::sync::Once::new());
     let event_windows = std::sync::Arc::clone(&windows);
 
@@ -78,9 +79,12 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
 
             Ok(())
         })
+        .on_window_ready(move |window| {
+            ready_windows.reserve(window);
+        })
         .on_webview_ready(move |webview| {
-            platform::register_webview_handlers(&webview);
             if windows.register(&webview) {
+                platform::register_webview_handlers(&webview);
                 let app_handle = webview.app_handle().clone();
                 let server_windows = std::sync::Arc::clone(&windows);
                 server_start.call_once(move || {

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -43,6 +43,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 /// This ignores the `TAURI_WEBDRIVER_PORT` environment variable.
 #[must_use]
 pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
+    let windows = std::sync::Arc::new(server::WindowRegistry::new());
+    let server_windows = std::sync::Arc::clone(&windows);
+
     Builder::new("wdio-webdriver")
         .setup(move |app, api| {
             #[cfg(mobile)]
@@ -63,7 +66,9 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
 
             // Arc so the (non-generic) objc2 message handler can hold its own clone; see eval_channel.
             #[cfg(target_os = "macos")]
-            app.manage(std::sync::Arc::new(eval_channel::EvalResultRegistry::default()));
+            app.manage(std::sync::Arc::new(
+                eval_channel::EvalResultRegistry::default(),
+            ));
 
             // Start the macOS headless run-loop pump early (before any webview loads); Once-guarded,
             // so the on_webview_ready registration remains a fallback. See #540.
@@ -72,12 +77,13 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
 
             // Start the WebDriver HTTP server
             let app_handle = app.app_handle().clone();
-            server::start(app_handle, port);
+            server::start(app_handle, port, std::sync::Arc::clone(&server_windows));
             tracing::info!("WDIO WebDriver plugin initialized on port {port}");
 
             Ok(())
         })
-        .on_webview_ready(|webview| {
+        .on_webview_ready(move |webview| {
+            windows.register(&webview);
             platform::register_webview_handlers(&webview);
         })
         .build()

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -85,10 +85,9 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
         .on_webview_ready(move |webview| {
             if windows.register(&webview) {
                 platform::register_webview_handlers(&webview);
-                let app_handle = webview.app_handle().clone();
                 let server_windows = std::sync::Arc::clone(&windows);
                 server_start.call_once(move || {
-                    server::start(app_handle, port, server_windows);
+                    server::start(port, server_windows);
                     tracing::info!("WDIO WebDriver plugin initialized on port {port}");
                 });
             }

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -44,7 +44,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 #[must_use]
 pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
     let windows = std::sync::Arc::new(server::WindowRegistry::new());
-    let server_windows = std::sync::Arc::clone(&windows);
+    let server_start = std::sync::Arc::new(std::sync::Once::new());
 
     Builder::new("wdio-webdriver")
         .setup(move |app, api| {
@@ -75,16 +75,18 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
             #[cfg(target_os = "macos")]
             platform::start_runloop_pump_early(app.app_handle());
 
-            // Start the WebDriver HTTP server
-            let app_handle = app.app_handle().clone();
-            server::start(app_handle, port, std::sync::Arc::clone(&server_windows));
-            tracing::info!("WDIO WebDriver plugin initialized on port {port}");
-
             Ok(())
         })
         .on_webview_ready(move |webview| {
-            windows.register(&webview);
             platform::register_webview_handlers(&webview);
+            if windows.register(&webview) {
+                let app_handle = webview.app_handle().clone();
+                let server_windows = std::sync::Arc::clone(&windows);
+                server_start.call_once(move || {
+                    server::start(app_handle, port, server_windows);
+                    tracing::info!("WDIO WebDriver plugin initialized on port {port}");
+                });
+            }
         })
         .build()
 }

--- a/packages/tauri-plugin-webdriver/src/lib.rs
+++ b/packages/tauri-plugin-webdriver/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
     plugin::{Builder, TauriPlugin},
-    Manager, Runtime,
+    Manager, RunEvent, Runtime, WindowEvent,
 };
 
 #[cfg(desktop)]
@@ -45,6 +45,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
     let windows = std::sync::Arc::new(server::WindowRegistry::new());
     let server_start = std::sync::Arc::new(std::sync::Once::new());
+    let event_windows = std::sync::Arc::clone(&windows);
 
     Builder::new("wdio-webdriver")
         .setup(move |app, api| {
@@ -86,6 +87,16 @@ pub fn init_with_port<R: Runtime>(port: u16) -> TauriPlugin<R> {
                     server::start(app_handle, port, server_windows);
                     tracing::info!("WDIO WebDriver plugin initialized on port {port}");
                 });
+            }
+        })
+        .on_event(move |_app, event| {
+            if let RunEvent::WindowEvent {
+                label,
+                event: WindowEvent::Destroyed,
+                ..
+            } = event
+            {
+                event_windows.destroyed_label(label);
             }
         })
         .build()

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, State};
 use axum::Json;
 use serde::Deserialize;
 use serde_json::json;
-use tauri::{Manager, Runtime};
+use tauri::Runtime;
 
 use crate::platform::WindowRect;
 use crate::server::response::{WebDriverErrorResponse, WebDriverResponse, WebDriverResult};
@@ -57,8 +57,7 @@ pub async fn get_window_handles<R: Runtime>(
     let _session = sessions.get(&session_id)?;
     drop(sessions);
 
-    // Return all window labels as handles
-    let handles: Vec<String> = state.app.webview_windows().keys().cloned().collect();
+    let handles = state.get_window_labels();
 
     Ok(WebDriverResponse::success(handles))
 }
@@ -84,14 +83,14 @@ pub async fn close_window<R: Runtime>(
         let current_window = session.current_window.clone();
         drop(sessions);
 
-        // Close the current window
-        if let Some(window) = state.app.webview_windows().get(&current_window).cloned() {
+        if let Some(window) = state.get_window(&current_window) {
             window
                 .destroy()
                 .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
 
-            // Return remaining window handles
-            let handles: Vec<String> = state.app.webview_windows().keys().cloned().collect();
+            let mut handles = state.get_window_labels();
+            handles.retain(|label| label != &current_window);
+            state.remove_window_label(&current_window);
 
             Ok(WebDriverResponse::success(handles))
         } else {
@@ -109,8 +108,7 @@ pub async fn switch_to_window<R: Runtime>(
     let mut sessions = state.sessions.write().await;
     let session = sessions.get_mut(&session_id)?;
 
-    // Verify the window exists
-    if !state.app.webview_windows().contains_key(&request.handle) {
+    if !state.has_window_label(&request.handle) {
         return Err(WebDriverErrorResponse::no_such_window());
     }
 

--- a/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
+++ b/packages/tauri-plugin-webdriver/src/server/handlers/window.rs
@@ -83,19 +83,17 @@ pub async fn close_window<R: Runtime>(
         let current_window = session.current_window.clone();
         drop(sessions);
 
-        if let Some(window) = state.get_window(&current_window) {
-            window
-                .destroy()
-                .map_err(|e| WebDriverErrorResponse::unknown_error(&e.to_string()))?;
+        let Some((window, generation)) = state.begin_close_window(&current_window) else {
+            return Err(WebDriverErrorResponse::no_such_window());
+        };
 
-            let mut handles = state.get_window_labels();
-            handles.retain(|label| label != &current_window);
-            state.remove_window_label(&current_window);
-
-            Ok(WebDriverResponse::success(handles))
-        } else {
-            Err(WebDriverErrorResponse::no_such_window())
+        if let Err(error) = window.destroy() {
+            state.rollback_close_window(&current_window, generation);
+            return Err(WebDriverErrorResponse::unknown_error(&error.to_string()));
         }
+
+        state.commit_close_window(&current_window, generation);
+        Ok(WebDriverResponse::success(state.get_window_labels()))
     }
 }
 

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Manager, Runtime, Webview, WebviewWindow, WindowEvent};
+use tauri::{AppHandle, Runtime, Webview, WebviewWindow, WindowEvent};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -40,40 +40,29 @@ impl<T: Clone> WindowCache<T> {
         }
     }
 
-    fn merge(&self, live_windows: impl IntoIterator<Item = (String, T)>) {
-        self.merge_with(|| live_windows);
+    fn next_generation(&self) -> u64 {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        Self::allocate_generation(&mut state)
     }
 
-    fn merge_with<I>(&self, get_live_windows: impl FnOnce() -> I)
-    where
-        I: IntoIterator<Item = (String, T)>,
-    {
+    fn publish(&self, label: String, value: T, generation: u64) -> bool {
         let mut state = self.state.write().expect("WindowCache poisoned");
-        for (label, value) in get_live_windows() {
-            if state.closing.contains_key(&label) {
-                continue;
-            }
-
-            if let Some(cached) = state.windows.get_mut(&label) {
-                cached.value = value;
-                continue;
-            }
-
-            let generation = Self::next_generation(&mut state);
-            state
-                .windows
-                .insert(label, CachedWindow { generation, value });
+        if state
+            .windows
+            .get(&label)
+            .is_some_and(|window| window.generation > generation)
+            || state
+                .closing
+                .get(&label)
+                .is_some_and(|closing_generation| *closing_generation >= generation)
+        {
+            return false;
         }
-    }
-
-    fn register(&self, label: String, value: T) -> u64 {
-        let mut state = self.state.write().expect("WindowCache poisoned");
-        let generation = Self::next_generation(&mut state);
         state.closing.remove(&label);
         state
             .windows
             .insert(label, CachedWindow { generation, value });
-        generation
+        true
     }
 
     fn get(&self, window_label: &str) -> Option<T> {
@@ -127,13 +116,28 @@ impl<T: Clone> WindowCache<T> {
         if state
             .windows
             .get(window_label)
+            .is_some_and(|window| window.generation > generation)
+            || state
+                .closing
+                .get(window_label)
+                .is_some_and(|closing_generation| *closing_generation > generation)
+        {
+            return;
+        }
+        if state
+            .windows
+            .get(window_label)
             .is_some_and(|window| window.generation == generation)
         {
             state.windows.remove(window_label);
         }
-        if state.closing.get(window_label) == Some(&generation) {
-            state.closing.remove(window_label);
-        }
+        state
+            .closing
+            .entry(window_label.to_string())
+            .and_modify(|closing_generation| {
+                *closing_generation = (*closing_generation).max(generation);
+            })
+            .or_insert(generation);
     }
 
     fn contains(&self, window_label: &str) -> bool {
@@ -151,7 +155,7 @@ impl<T: Clone> WindowCache<T> {
             .collect()
     }
 
-    fn next_generation(state: &mut WindowCacheState<T>) -> u64 {
+    fn allocate_generation(state: &mut WindowCacheState<T>) -> u64 {
         let generation = state.next_generation;
         state.next_generation = state
             .next_generation
@@ -170,26 +174,18 @@ pub struct AppState<R: Runtime> {
 
 impl<R: Runtime + 'static> AppState<R> {
     pub fn new(app: AppHandle<R>, windows: Arc<WindowRegistry<R>>) -> Self {
-        let state = Self {
+        Self {
             app,
             sessions: RwLock::new(SessionManager::new()),
             windows,
-        };
-        state.refresh_windows();
-        state
-    }
-
-    fn refresh_windows(&self) {
-        self.windows.refresh(&self.app);
+        }
     }
 
     fn get_window(&self, window_label: &str) -> Option<WebviewWindow<R>> {
-        self.refresh_windows();
         self.windows.get(window_label)
     }
 
     fn begin_close_window(&self, window_label: &str) -> Option<(WebviewWindow<R>, u64)> {
-        self.refresh_windows();
         self.windows.begin_close(window_label)
     }
 
@@ -215,13 +211,11 @@ impl<R: Runtime + 'static> AppState<R> {
 
     /// Whether a window with this label has been registered
     pub fn has_window_label(&self, window_label: &str) -> bool {
-        self.refresh_windows();
         self.windows.contains(window_label)
     }
 
     /// Get all window labels
     pub fn get_window_labels(&self) -> Vec<String> {
-        self.refresh_windows();
         self.windows.labels()
     }
 }
@@ -238,28 +232,25 @@ impl<R: Runtime> WindowRegistry<R> {
         }
     }
 
-    pub(crate) fn register(self: &Arc<Self>, webview: &Webview<R>) {
+    pub(crate) fn register(self: &Arc<Self>, webview: &Webview<R>) -> bool {
         let window = webview.window();
         if webview.label() != window.label() {
-            return;
+            return false;
         }
 
         let label = window.label().to_string();
         let Some(webview_window) = webview.app_handle().get_webview_window(&label) else {
-            return;
+            return false;
         };
-        let generation = self.windows.register(label.clone(), webview_window);
-
+        let generation = self.windows.next_generation();
         let windows = Arc::clone(self);
+        let destroyed_label = label.clone();
         window.on_window_event(move |event| {
             if matches!(event, WindowEvent::Destroyed) {
-                windows.destroyed(&label, generation);
+                windows.destroyed(&destroyed_label, generation);
             }
         });
-    }
-
-    fn refresh(&self, app: &AppHandle<R>) {
-        self.windows.merge_with(|| app.webview_windows());
+        self.windows.publish(label, webview_window, generation)
     }
 
     fn get(&self, window_label: &str) -> Option<WebviewWindow<R>> {
@@ -295,12 +286,16 @@ impl<R: Runtime> WindowRegistry<R> {
 mod tests {
     use super::WindowCache;
 
-    #[test]
-    fn should_preserve_a_cached_main_window_when_live_enumeration_loses_it() {
-        let cached = WindowCache::new();
-        cached.merge([("main".to_string(), 1)]);
+    fn publish<T: Clone>(cached: &WindowCache<T>, label: &str, value: T) -> u64 {
+        let generation = cached.next_generation();
+        assert!(cached.publish(label.to_string(), value, generation));
+        generation
+    }
 
-        cached.merge(std::iter::empty());
+    #[test]
+    fn should_preserve_a_cached_main_window_after_live_enumeration_loses_it() {
+        let cached = WindowCache::new();
+        publish(&cached, "main", 1);
 
         assert_eq!(cached.get("main"), Some(1));
     }
@@ -308,7 +303,7 @@ mod tests {
     #[test]
     fn should_remove_a_closed_window_from_the_cache() {
         let cached = WindowCache::new();
-        cached.merge([("main".to_string(), 1)]);
+        publish(&cached, "main", 1);
 
         let (_, generation) = cached.begin_close("main").unwrap();
         cached.commit_close("main", generation);
@@ -317,11 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn should_merge_windows_discovered_later_without_inventing_child_handles() {
+    fn should_register_later_top_level_windows_without_inventing_child_handles() {
         let cached = WindowCache::new();
-        cached.merge([("main".to_string(), 1)]);
-
-        cached.merge([("settings".to_string(), 2)]);
+        publish(&cached, "main", 1);
+        publish(&cached, "settings", 2);
 
         assert_eq!(cached.labels().len(), 2);
         assert_eq!(cached.get("main"), Some(1));
@@ -332,11 +326,10 @@ mod tests {
     #[test]
     fn should_not_restore_a_closing_window_from_a_stale_live_snapshot() {
         let cached = WindowCache::new();
-        cached.merge([("main".to_string(), 1)]);
+        publish(&cached, "main", 1);
 
         let (_, generation) = cached.begin_close("main").unwrap();
         cached.commit_close("main", generation);
-        cached.merge([("main".to_string(), 1)]);
 
         assert!(!cached.contains("main"));
     }
@@ -344,7 +337,7 @@ mod tests {
     #[test]
     fn should_restore_a_window_when_destroy_fails() {
         let cached = WindowCache::new();
-        cached.merge([("main".to_string(), 1)]);
+        publish(&cached, "main", 1);
 
         let (_, generation) = cached.begin_close("main").unwrap();
         assert!(!cached.contains("main"));
@@ -356,15 +349,36 @@ mod tests {
     #[test]
     fn should_keep_a_new_window_when_an_old_window_with_the_same_label_is_destroyed() {
         let cached = WindowCache::new();
-        let old_generation = cached.register("main".to_string(), 1);
+        let old_generation = publish(&cached, "main", 1);
         let (_, closing_generation) = cached.begin_close("main").unwrap();
         cached.commit_close("main", closing_generation);
-        cached.merge([("main".to_string(), 1)]);
-
-        let new_generation = cached.register("main".to_string(), 2);
+        let new_generation = publish(&cached, "main", 2);
         cached.destroyed("main", old_generation);
 
         assert_ne!(old_generation, new_generation);
+        assert_eq!(cached.get("main"), Some(2));
+    }
+
+    #[test]
+    fn should_reject_a_registration_destroyed_before_it_is_published() {
+        let cached = WindowCache::new();
+        let generation = cached.next_generation();
+
+        cached.destroyed("main", generation);
+
+        assert!(!cached.publish("main".to_string(), 1, generation));
+        assert!(!cached.contains("main"));
+    }
+
+    #[test]
+    fn should_reject_an_older_registration_that_finishes_after_a_newer_one() {
+        let cached = WindowCache::new();
+        let older_generation = cached.next_generation();
+        let newer_generation = cached.next_generation();
+
+        assert!(cached.publish("main".to_string(), 2, newer_generation));
+        assert!(!cached.publish("main".to_string(), 1, older_generation));
+
         assert_eq!(cached.get("main"), Some(2));
     }
 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Manager, Runtime, Webview, WebviewWindow, Window};
+use tauri::{Manager, Runtime, Webview, WebviewWindow, Window};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -229,15 +229,13 @@ impl<T: Clone> WindowCache<T> {
 
 /// Shared state for the `WebDriver` server
 pub struct AppState<R: Runtime> {
-    pub app: AppHandle<R>,
     pub sessions: RwLock<SessionManager>,
     windows: Arc<WindowRegistry<R>>,
 }
 
 impl<R: Runtime + 'static> AppState<R> {
-    pub fn new(app: AppHandle<R>, windows: Arc<WindowRegistry<R>>) -> Self {
+    pub fn new(windows: Arc<WindowRegistry<R>>) -> Self {
         Self {
-            app,
             sessions: RwLock::new(SessionManager::new()),
             windows,
         }
@@ -331,6 +329,49 @@ impl<R: Runtime> WindowRegistry<R> {
     fn labels(&self) -> Vec<String> {
         self.windows.labels()
     }
+}
+
+/// Start the `WebDriver` HTTP server on the specified port
+pub fn start<R: Runtime + 'static>(port: u16, windows: Arc<WindowRegistry<R>>) {
+    std::thread::spawn(move || {
+        let rt = match TokioRuntime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                tracing::error!("Failed to create Tokio runtime for WebDriver server: {}", e);
+                return;
+            }
+        };
+
+        rt.block_on(async {
+            let state = Arc::new(AppState::new(windows));
+            let router = router::create_router(state);
+
+            // On Android, bind to all interfaces for WiFi accessibility
+            // On other platforms, bind to localhost only for security
+            #[cfg(target_os = "android")]
+            let addr = SocketAddr::from(([0, 0, 0, 0], port));
+            #[cfg(not(target_os = "android"))]
+            let addr = SocketAddr::from(([127, 0, 0, 1], port));
+
+            let listener = match tokio::net::TcpListener::bind(addr).await {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to bind WebDriver server to {} — port may already be in use: {}",
+                        addr,
+                        e
+                    );
+                    return;
+                }
+            };
+
+            tracing::info!("WebDriver server listening on http://{}", addr);
+
+            if let Err(e) = axum::serve(listener, router).await {
+                tracing::error!("WebDriver server error: {}", e);
+            }
+        });
+    });
 }
 
 #[cfg(test)]
@@ -463,47 +504,4 @@ mod tests {
         assert_ne!(older_generation, newer_generation);
         assert_eq!(cached.get("main"), Some(2));
     }
-}
-
-/// Start the `WebDriver` HTTP server on the specified port
-pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16, windows: Arc<WindowRegistry<R>>) {
-    std::thread::spawn(move || {
-        let rt = match TokioRuntime::new() {
-            Ok(rt) => rt,
-            Err(e) => {
-                tracing::error!("Failed to create Tokio runtime for WebDriver server: {}", e);
-                return;
-            }
-        };
-
-        rt.block_on(async {
-            let state = Arc::new(AppState::new(app, windows));
-            let router = router::create_router(state);
-
-            // On Android, bind to all interfaces for WiFi accessibility
-            // On other platforms, bind to localhost only for security
-            #[cfg(target_os = "android")]
-            let addr = SocketAddr::from(([0, 0, 0, 0], port));
-            #[cfg(not(target_os = "android"))]
-            let addr = SocketAddr::from(([127, 0, 0, 1], port));
-
-            let listener = match tokio::net::TcpListener::bind(addr).await {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to bind WebDriver server to {} — port may already be in use: {}",
-                        addr,
-                        e
-                    );
-                    return;
-                }
-            };
-
-            tracing::info!("WebDriver server listening on http://{}", addr);
-
-            if let Err(e) = axum::serve(listener, router).await {
-                tracing::error!("WebDriver server error: {}", e);
-            }
-        });
-    });
 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Runtime, Webview, WebviewWindow, WindowEvent};
+use tauri::{AppHandle, Runtime, Webview, WebviewWindow};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -21,6 +21,7 @@ struct WindowCache<T> {
 struct WindowCacheState<T> {
     windows: HashMap<String, CachedWindow<T>>,
     closing: HashMap<String, u64>,
+    lifecycles: HashMap<String, VecDeque<u64>>,
     next_generation: u64,
 }
 
@@ -35,14 +36,21 @@ impl<T: Clone> WindowCache<T> {
             state: SyncRwLock::new(WindowCacheState {
                 windows: HashMap::new(),
                 closing: HashMap::new(),
+                lifecycles: HashMap::new(),
                 next_generation: 0,
             }),
         }
     }
 
-    fn next_generation(&self) -> u64 {
+    fn track(&self, label: &str) -> u64 {
         let mut state = self.state.write().expect("WindowCache poisoned");
-        Self::allocate_generation(&mut state)
+        let generation = Self::allocate_generation(&mut state);
+        state
+            .lifecycles
+            .entry(label.to_string())
+            .or_default()
+            .push_back(generation);
+        generation
     }
 
     fn publish(&self, label: String, value: T, generation: u64) -> bool {
@@ -138,6 +146,25 @@ impl<T: Clone> WindowCache<T> {
                 *closing_generation = (*closing_generation).max(generation);
             })
             .or_insert(generation);
+    }
+
+    fn destroyed_label(&self, window_label: &str) {
+        let generation = {
+            let mut state = self.state.write().expect("WindowCache poisoned");
+            let generations = match state.lifecycles.get_mut(window_label) {
+                Some(generations) => generations,
+                None => return,
+            };
+            let generation = match generations.pop_front() {
+                Some(generation) => generation,
+                None => return,
+            };
+            if generations.is_empty() {
+                state.lifecycles.remove(window_label);
+            }
+            generation
+        };
+        self.destroyed(window_label, generation);
     }
 
     fn contains(&self, window_label: &str) -> bool {
@@ -242,14 +269,7 @@ impl<R: Runtime> WindowRegistry<R> {
         let Some(webview_window) = webview.app_handle().get_webview_window(&label) else {
             return false;
         };
-        let generation = self.windows.next_generation();
-        let windows = Arc::clone(self);
-        let destroyed_label = label.clone();
-        window.on_window_event(move |event| {
-            if matches!(event, WindowEvent::Destroyed) {
-                windows.destroyed(&destroyed_label, generation);
-            }
-        });
+        let generation = self.windows.track(&label);
         self.windows.publish(label, webview_window, generation)
     }
 
@@ -269,8 +289,8 @@ impl<R: Runtime> WindowRegistry<R> {
         self.windows.rollback_close(window_label, generation);
     }
 
-    fn destroyed(&self, window_label: &str, generation: u64) {
-        self.windows.destroyed(window_label, generation);
+    pub(crate) fn destroyed_label(&self, window_label: &str) {
+        self.windows.destroyed_label(window_label);
     }
 
     fn contains(&self, window_label: &str) -> bool {
@@ -287,7 +307,7 @@ mod tests {
     use super::WindowCache;
 
     fn publish<T: Clone>(cached: &WindowCache<T>, label: &str, value: T) -> u64 {
-        let generation = cached.next_generation();
+        let generation = cached.track(label);
         assert!(cached.publish(label.to_string(), value, generation));
         generation
     }
@@ -353,18 +373,21 @@ mod tests {
         let (_, closing_generation) = cached.begin_close("main").unwrap();
         cached.commit_close("main", closing_generation);
         let new_generation = publish(&cached, "main", 2);
-        cached.destroyed("main", old_generation);
+        cached.destroyed_label("main");
 
         assert_ne!(old_generation, new_generation);
         assert_eq!(cached.get("main"), Some(2));
+
+        cached.destroyed_label("main");
+        assert!(!cached.contains("main"));
     }
 
     #[test]
     fn should_reject_a_registration_destroyed_before_it_is_published() {
         let cached = WindowCache::new();
-        let generation = cached.next_generation();
+        let generation = cached.track("main");
 
-        cached.destroyed("main", generation);
+        cached.destroyed_label("main");
 
         assert!(!cached.publish("main".to_string(), 1, generation));
         assert!(!cached.contains("main"));
@@ -373,11 +396,12 @@ mod tests {
     #[test]
     fn should_reject_an_older_registration_that_finishes_after_a_newer_one() {
         let cached = WindowCache::new();
-        let older_generation = cached.next_generation();
-        let newer_generation = cached.next_generation();
+        let older_generation = cached.track("main");
+        let newer_generation = cached.track("main");
 
         assert!(cached.publish("main".to_string(), 2, newer_generation));
         assert!(!cached.publish("main".to_string(), 1, older_generation));
+        cached.destroyed_label("main");
 
         assert_eq!(cached.get("main"), Some(2));
     }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Runtime, Webview, WebviewWindow};
+use tauri::{AppHandle, Manager, Runtime, Webview, WebviewWindow, Window};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -21,6 +21,7 @@ struct WindowCache<T> {
 struct WindowCacheState<T> {
     windows: HashMap<String, CachedWindow<T>>,
     closing: HashMap<String, u64>,
+    registrations: HashMap<String, VecDeque<u64>>,
     lifecycles: HashMap<String, VecDeque<u64>>,
     next_generation: u64,
 }
@@ -36,21 +37,49 @@ impl<T: Clone> WindowCache<T> {
             state: SyncRwLock::new(WindowCacheState {
                 windows: HashMap::new(),
                 closing: HashMap::new(),
+                registrations: HashMap::new(),
                 lifecycles: HashMap::new(),
                 next_generation: 0,
             }),
         }
     }
 
-    fn track(&self, label: &str) -> u64 {
+    fn reserve(&self, label: &str) -> u64 {
         let mut state = self.state.write().expect("WindowCache poisoned");
         let generation = Self::allocate_generation(&mut state);
+        state
+            .registrations
+            .entry(label.to_string())
+            .or_default()
+            .push_back(generation);
         state
             .lifecycles
             .entry(label.to_string())
             .or_default()
             .push_back(generation);
         generation
+    }
+
+    fn publish_reserved_with(&self, label: &str, create_value: impl FnOnce() -> Option<T>) -> bool {
+        let generation = {
+            let mut state = self.state.write().expect("WindowCache poisoned");
+            let registrations = match state.registrations.get_mut(label) {
+                Some(registrations) => registrations,
+                None => return false,
+            };
+            let generation = match registrations.pop_front() {
+                Some(generation) => generation,
+                None => return false,
+            };
+            if registrations.is_empty() {
+                state.registrations.remove(label);
+            }
+            generation
+        };
+        match create_value() {
+            Some(value) => self.publish(label.to_string(), value, generation),
+            None => false,
+        }
     }
 
     fn publish(&self, label: String, value: T, generation: u64) -> bool {
@@ -138,6 +167,12 @@ impl<T: Clone> WindowCache<T> {
             .is_some_and(|window| window.generation == generation)
         {
             state.windows.remove(window_label);
+        }
+        if let Some(registrations) = state.registrations.get_mut(window_label) {
+            registrations.retain(|registration| *registration != generation);
+            if registrations.is_empty() {
+                state.registrations.remove(window_label);
+            }
         }
         state
             .closing
@@ -259,18 +294,14 @@ impl<R: Runtime> WindowRegistry<R> {
         }
     }
 
-    pub(crate) fn register(self: &Arc<Self>, webview: &Webview<R>) -> bool {
-        let window = webview.window();
-        if webview.label() != window.label() {
-            return false;
-        }
+    pub(crate) fn reserve(&self, window: Window<R>) {
+        self.windows.reserve(window.label());
+    }
 
-        let label = window.label().to_string();
-        let Some(webview_window) = webview.app_handle().get_webview_window(&label) else {
-            return false;
-        };
-        let generation = self.windows.track(&label);
-        self.windows.publish(label, webview_window, generation)
+    pub(crate) fn register(&self, webview: &Webview<R>) -> bool {
+        let label = webview.label();
+        self.windows
+            .publish_reserved_with(label, || webview.app_handle().get_webview_window(label))
     }
 
     fn get(&self, window_label: &str) -> Option<WebviewWindow<R>> {
@@ -307,8 +338,8 @@ mod tests {
     use super::WindowCache;
 
     fn publish<T: Clone>(cached: &WindowCache<T>, label: &str, value: T) -> u64 {
-        let generation = cached.track(label);
-        assert!(cached.publish(label.to_string(), value, generation));
+        let generation = cached.reserve(label);
+        assert!(cached.publish_reserved_with(label, || Some(value)));
         generation
     }
 
@@ -385,24 +416,51 @@ mod tests {
     #[test]
     fn should_reject_a_registration_destroyed_before_it_is_published() {
         let cached = WindowCache::new();
-        let generation = cached.track("main");
+        cached.reserve("main");
 
         cached.destroyed_label("main");
 
-        assert!(!cached.publish("main".to_string(), 1, generation));
+        assert!(!cached.publish_reserved_with("main", || Some(1)));
         assert!(!cached.contains("main"));
     }
 
     #[test]
-    fn should_reject_an_older_registration_that_finishes_after_a_newer_one() {
+    fn should_preserve_a_new_pending_registration_after_an_old_destroy() {
         let cached = WindowCache::new();
-        let older_generation = cached.track("main");
-        let newer_generation = cached.track("main");
+        cached.reserve("main");
+        cached.reserve("main");
 
-        assert!(cached.publish("main".to_string(), 2, newer_generation));
-        assert!(!cached.publish("main".to_string(), 1, older_generation));
         cached.destroyed_label("main");
 
+        assert!(cached.publish_reserved_with("main", || Some(2)));
+        assert_eq!(cached.get("main"), Some(2));
+    }
+
+    #[test]
+    fn should_ignore_an_unreserved_child_without_creating_its_window() {
+        let cached = WindowCache::new();
+        publish(&cached, "main", 1);
+        let mut factory_called = false;
+
+        assert!(!cached.publish_reserved_with("child", || {
+            factory_called = true;
+            Some(2)
+        }));
+        assert!(!factory_called);
+        assert!(!cached.contains("child"));
+    }
+
+    #[test]
+    fn should_publish_same_label_registrations_in_lifecycle_order() {
+        let cached = WindowCache::new();
+        let older_generation = cached.reserve("main");
+        let newer_generation = cached.reserve("main");
+
+        assert!(cached.publish_reserved_with("main", || Some(1)));
+        assert!(cached.publish_reserved_with("main", || Some(2)));
+        cached.destroyed_label("main");
+
+        assert_ne!(older_generation, newer_generation);
         assert_eq!(cached.get("main"), Some(2));
     }
 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -15,13 +15,28 @@ use crate::server::response::WebDriverErrorResponse;
 use crate::webdriver::{SessionManager, Timeouts};
 
 struct WindowCache<T> {
-    windows: SyncRwLock<HashMap<String, T>>,
+    state: SyncRwLock<WindowCacheState<T>>,
+}
+
+struct WindowCacheState<T> {
+    windows: HashMap<String, CachedWindow<T>>,
+    closing: HashMap<String, u64>,
+    next_generation: u64,
+}
+
+struct CachedWindow<T> {
+    generation: u64,
+    value: T,
 }
 
 impl<T: Clone> WindowCache<T> {
     fn new() -> Self {
         Self {
-            windows: SyncRwLock::new(HashMap::new()),
+            state: SyncRwLock::new(WindowCacheState {
+                windows: HashMap::new(),
+                closing: HashMap::new(),
+                next_generation: 0,
+            }),
         }
     }
 
@@ -33,41 +48,116 @@ impl<T: Clone> WindowCache<T> {
     where
         I: IntoIterator<Item = (String, T)>,
     {
-        self.windows
-            .write()
-            .expect("WindowCache poisoned")
-            .extend(get_live_windows());
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        for (label, value) in get_live_windows() {
+            if state.closing.contains_key(&label) {
+                continue;
+            }
+
+            if let Some(cached) = state.windows.get_mut(&label) {
+                cached.value = value;
+                continue;
+            }
+
+            let generation = Self::next_generation(&mut state);
+            state
+                .windows
+                .insert(label, CachedWindow { generation, value });
+        }
+    }
+
+    fn register(&self, label: String, value: T) -> u64 {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        let generation = Self::next_generation(&mut state);
+        state.closing.remove(&label);
+        state
+            .windows
+            .insert(label, CachedWindow { generation, value });
+        generation
     }
 
     fn get(&self, window_label: &str) -> Option<T> {
-        self.windows
-            .read()
-            .expect("WindowCache poisoned")
+        let state = self.state.read().expect("WindowCache poisoned");
+        if state.closing.contains_key(window_label) {
+            return None;
+        }
+        state
+            .windows
             .get(window_label)
+            .map(|window| &window.value)
             .cloned()
     }
 
-    fn remove(&self, window_label: &str) {
-        self.windows
-            .write()
-            .expect("WindowCache poisoned")
-            .remove(window_label);
+    fn begin_close(&self, window_label: &str) -> Option<(T, u64)> {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        if state.closing.contains_key(window_label) {
+            return None;
+        }
+        let (value, generation) = state
+            .windows
+            .get(window_label)
+            .map(|window| (window.value.clone(), window.generation))?;
+        state.closing.insert(window_label.to_string(), generation);
+        Some((value, generation))
+    }
+
+    fn commit_close(&self, window_label: &str, generation: u64) {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        if state.closing.get(window_label) != Some(&generation) {
+            return;
+        }
+        if state
+            .windows
+            .get(window_label)
+            .is_some_and(|window| window.generation == generation)
+        {
+            state.windows.remove(window_label);
+        }
+    }
+
+    fn rollback_close(&self, window_label: &str, generation: u64) {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        if state.closing.get(window_label) == Some(&generation) {
+            state.closing.remove(window_label);
+        }
+    }
+
+    fn destroyed(&self, window_label: &str, generation: u64) {
+        let mut state = self.state.write().expect("WindowCache poisoned");
+        if state
+            .windows
+            .get(window_label)
+            .is_some_and(|window| window.generation == generation)
+        {
+            state.windows.remove(window_label);
+        }
+        if state.closing.get(window_label) == Some(&generation) {
+            state.closing.remove(window_label);
+        }
     }
 
     fn contains(&self, window_label: &str) -> bool {
-        self.windows
-            .read()
-            .expect("WindowCache poisoned")
-            .contains_key(window_label)
+        let state = self.state.read().expect("WindowCache poisoned");
+        !state.closing.contains_key(window_label) && state.windows.contains_key(window_label)
     }
 
     fn labels(&self) -> Vec<String> {
-        self.windows
-            .read()
-            .expect("WindowCache poisoned")
+        let state = self.state.read().expect("WindowCache poisoned");
+        state
+            .windows
             .keys()
+            .filter(|label| !state.closing.contains_key(*label))
             .cloned()
             .collect()
+    }
+
+    fn next_generation(state: &mut WindowCacheState<T>) -> u64 {
+        let generation = state.next_generation;
+        state.next_generation = state
+            .next_generation
+            .checked_add(1)
+            .expect("WindowCache generation overflowed");
+        generation
     }
 }
 
@@ -98,8 +188,17 @@ impl<R: Runtime + 'static> AppState<R> {
         self.windows.get(window_label)
     }
 
-    pub fn remove_window_label(&self, window_label: &str) {
-        self.windows.remove(window_label);
+    fn begin_close_window(&self, window_label: &str) -> Option<(WebviewWindow<R>, u64)> {
+        self.refresh_windows();
+        self.windows.begin_close(window_label)
+    }
+
+    fn commit_close_window(&self, window_label: &str, generation: u64) {
+        self.windows.commit_close(window_label, generation);
+    }
+
+    fn rollback_close_window(&self, window_label: &str, generation: u64) {
+        self.windows.rollback_close(window_label, generation);
     }
 
     /// Get a platform executor for a specific window by label
@@ -149,18 +248,14 @@ impl<R: Runtime> WindowRegistry<R> {
         let Some(webview_window) = webview.app_handle().get_webview_window(&label) else {
             return;
         };
-        self.merge([(label.clone(), webview_window)]);
+        let generation = self.windows.register(label.clone(), webview_window);
 
         let windows = Arc::clone(self);
         window.on_window_event(move |event| {
             if matches!(event, WindowEvent::Destroyed) {
-                windows.remove(&label);
+                windows.destroyed(&label, generation);
             }
         });
-    }
-
-    fn merge(&self, live_windows: impl IntoIterator<Item = (String, WebviewWindow<R>)>) {
-        self.windows.merge(live_windows);
     }
 
     fn refresh(&self, app: &AppHandle<R>) {
@@ -171,8 +266,20 @@ impl<R: Runtime> WindowRegistry<R> {
         self.windows.get(window_label)
     }
 
-    fn remove(&self, window_label: &str) {
-        self.windows.remove(window_label);
+    fn begin_close(&self, window_label: &str) -> Option<(WebviewWindow<R>, u64)> {
+        self.windows.begin_close(window_label)
+    }
+
+    fn commit_close(&self, window_label: &str, generation: u64) {
+        self.windows.commit_close(window_label, generation);
+    }
+
+    fn rollback_close(&self, window_label: &str, generation: u64) {
+        self.windows.rollback_close(window_label, generation);
+    }
+
+    fn destroyed(&self, window_label: &str, generation: u64) {
+        self.windows.destroyed(window_label, generation);
     }
 
     fn contains(&self, window_label: &str) -> bool {
@@ -187,8 +294,6 @@ impl<R: Runtime> WindowRegistry<R> {
 #[cfg(test)]
 mod tests {
     use super::WindowCache;
-    use std::sync::{mpsc, Arc};
-    use std::thread;
 
     #[test]
     fn should_preserve_a_cached_main_window_when_live_enumeration_loses_it() {
@@ -205,7 +310,8 @@ mod tests {
         let cached = WindowCache::new();
         cached.merge([("main".to_string(), 1)]);
 
-        cached.remove("main");
+        let (_, generation) = cached.begin_close("main").unwrap();
+        cached.commit_close("main", generation);
 
         assert!(!cached.contains("main"));
     }
@@ -224,29 +330,42 @@ mod tests {
     }
 
     #[test]
-    fn should_not_restore_a_window_removed_during_a_live_refresh() {
-        let cached = Arc::new(WindowCache::new());
+    fn should_not_restore_a_closing_window_from_a_stale_live_snapshot() {
+        let cached = WindowCache::new();
         cached.merge([("main".to_string(), 1)]);
-        let (refresh_started_tx, refresh_started_rx) = mpsc::channel();
-        let (continue_refresh_tx, continue_refresh_rx) = mpsc::channel();
 
-        let refresh_cache = Arc::clone(&cached);
-        let refresh = thread::spawn(move || {
-            refresh_cache.merge_with(|| {
-                refresh_started_tx.send(()).unwrap();
-                continue_refresh_rx.recv().unwrap();
-                [("main".to_string(), 1)]
-            });
-        });
-        refresh_started_rx.recv().unwrap();
+        let (_, generation) = cached.begin_close("main").unwrap();
+        cached.commit_close("main", generation);
+        cached.merge([("main".to_string(), 1)]);
 
-        let remove_cache = Arc::clone(&cached);
-        let remove = thread::spawn(move || remove_cache.remove("main"));
-        continue_refresh_tx.send(()).unwrap();
-
-        refresh.join().unwrap();
-        remove.join().unwrap();
         assert!(!cached.contains("main"));
+    }
+
+    #[test]
+    fn should_restore_a_window_when_destroy_fails() {
+        let cached = WindowCache::new();
+        cached.merge([("main".to_string(), 1)]);
+
+        let (_, generation) = cached.begin_close("main").unwrap();
+        assert!(!cached.contains("main"));
+        cached.rollback_close("main", generation);
+
+        assert_eq!(cached.get("main"), Some(1));
+    }
+
+    #[test]
+    fn should_keep_a_new_window_when_an_old_window_with_the_same_label_is_destroyed() {
+        let cached = WindowCache::new();
+        let old_generation = cached.register("main".to_string(), 1);
+        let (_, closing_generation) = cached.begin_close("main").unwrap();
+        cached.commit_close("main", closing_generation);
+        cached.merge([("main".to_string(), 1)]);
+
+        let new_generation = cached.register("main".to_string(), 2);
+        cached.destroyed("main", old_generation);
+
+        assert_ne!(old_generation, new_generation);
+        assert_eq!(cached.get("main"), Some(2));
     }
 }
 

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Manager, Runtime, WebviewWindow};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -13,18 +14,77 @@ use crate::platform::{create_executor, FrameId, PlatformExecutor};
 use crate::server::response::WebDriverErrorResponse;
 use crate::webdriver::{SessionManager, Timeouts};
 
+struct WindowCache<T> {
+    windows: HashMap<String, T>,
+}
+
+impl<T: Clone> WindowCache<T> {
+    fn new() -> Self {
+        Self {
+            windows: HashMap::new(),
+        }
+    }
+
+    fn merge(&mut self, live_windows: impl IntoIterator<Item = (String, T)>) {
+        self.windows.extend(live_windows);
+    }
+
+    fn get(&self, window_label: &str) -> Option<T> {
+        self.windows.get(window_label).cloned()
+    }
+
+    fn remove(&mut self, window_label: &str) {
+        self.windows.remove(window_label);
+    }
+
+    fn contains(&self, window_label: &str) -> bool {
+        self.windows.contains_key(window_label)
+    }
+
+    fn labels(&self) -> Vec<String> {
+        self.windows.keys().cloned().collect()
+    }
+}
+
 /// Shared state for the `WebDriver` server
 pub struct AppState<R: Runtime> {
     pub app: AppHandle<R>,
     pub sessions: RwLock<SessionManager>,
+    // Tauri can stop enumerating a parent WebviewWindow after it gains child webviews.
+    windows: SyncRwLock<WindowCache<WebviewWindow<R>>>,
 }
 
 impl<R: Runtime + 'static> AppState<R> {
     pub fn new(app: AppHandle<R>) -> Self {
-        Self {
+        let state = Self {
             app,
             sessions: RwLock::new(SessionManager::new()),
-        }
+            windows: SyncRwLock::new(WindowCache::new()),
+        };
+        state.refresh_windows();
+        state
+    }
+
+    fn refresh_windows(&self) {
+        self.windows
+            .write()
+            .expect("AppState window cache poisoned")
+            .merge(self.app.webview_windows());
+    }
+
+    fn get_window(&self, window_label: &str) -> Option<WebviewWindow<R>> {
+        self.refresh_windows();
+        self.windows
+            .read()
+            .expect("AppState window cache poisoned")
+            .get(window_label)
+    }
+
+    pub fn remove_window_label(&self, window_label: &str) {
+        self.windows
+            .write()
+            .expect("AppState window cache poisoned")
+            .remove(window_label);
     }
 
     /// Get a platform executor for a specific window by label
@@ -34,22 +94,63 @@ impl<R: Runtime + 'static> AppState<R> {
         timeouts: Timeouts,
         frame_context: Vec<FrameId>,
     ) -> Result<Arc<dyn PlatformExecutor<R>>, WebDriverErrorResponse> {
-        self.app
-            .webview_windows()
-            .get(window_label)
-            .cloned()
+        self.get_window(window_label)
             .map(|window| create_executor(window, timeouts, frame_context))
             .ok_or_else(WebDriverErrorResponse::no_such_window)
     }
 
-    /// Whether a window with this label is still registered
+    /// Whether a window with this label has been registered
     pub fn has_window_label(&self, window_label: &str) -> bool {
-        self.app.webview_windows().contains_key(window_label)
+        self.refresh_windows();
+        self.windows
+            .read()
+            .expect("AppState window cache poisoned")
+            .contains(window_label)
     }
 
     /// Get all window labels
     pub fn get_window_labels(&self) -> Vec<String> {
-        self.app.webview_windows().keys().cloned().collect()
+        self.refresh_windows();
+        let windows = self.windows.read().expect("AppState window cache poisoned");
+        windows.labels()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WindowCache;
+
+    #[test]
+    fn should_preserve_a_cached_main_window_when_live_enumeration_loses_it() {
+        let mut cached = WindowCache::new();
+        cached.merge([("main".to_string(), 1)]);
+
+        cached.merge(std::iter::empty());
+
+        assert_eq!(cached.get("main"), Some(1));
+    }
+
+    #[test]
+    fn should_remove_a_closed_window_from_the_cache() {
+        let mut cached = WindowCache::new();
+        cached.merge([("main".to_string(), 1)]);
+
+        cached.remove("main");
+
+        assert!(!cached.contains("main"));
+    }
+
+    #[test]
+    fn should_merge_windows_discovered_later_without_inventing_child_handles() {
+        let mut cached = WindowCache::new();
+        cached.merge([("main".to_string(), 1)]);
+
+        cached.merge([("settings".to_string(), 2)]);
+
+        assert_eq!(cached.labels().len(), 2);
+        assert_eq!(cached.get("main"), Some(1));
+        assert_eq!(cached.get("settings"), Some(2));
+        assert!(!cached.contains("child-webview"));
     }
 }
 
@@ -80,7 +181,8 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
                 Err(e) => {
                     tracing::error!(
                         "Failed to bind WebDriver server to {} — port may already be in use: {}",
-                        addr, e
+                        addr,
+                        e
                     );
                     return;
                 }

--- a/packages/tauri-plugin-webdriver/src/server/mod.rs
+++ b/packages/tauri-plugin-webdriver/src/server/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock as SyncRwLock};
 
-use tauri::{AppHandle, Manager, Runtime, WebviewWindow};
+use tauri::{AppHandle, Manager, Runtime, Webview, WebviewWindow, WindowEvent};
 use tokio::runtime::Runtime as TokioRuntime;
 use tokio::sync::RwLock;
 
@@ -15,34 +15,59 @@ use crate::server::response::WebDriverErrorResponse;
 use crate::webdriver::{SessionManager, Timeouts};
 
 struct WindowCache<T> {
-    windows: HashMap<String, T>,
+    windows: SyncRwLock<HashMap<String, T>>,
 }
 
 impl<T: Clone> WindowCache<T> {
     fn new() -> Self {
         Self {
-            windows: HashMap::new(),
+            windows: SyncRwLock::new(HashMap::new()),
         }
     }
 
-    fn merge(&mut self, live_windows: impl IntoIterator<Item = (String, T)>) {
-        self.windows.extend(live_windows);
+    fn merge(&self, live_windows: impl IntoIterator<Item = (String, T)>) {
+        self.merge_with(|| live_windows);
+    }
+
+    fn merge_with<I>(&self, get_live_windows: impl FnOnce() -> I)
+    where
+        I: IntoIterator<Item = (String, T)>,
+    {
+        self.windows
+            .write()
+            .expect("WindowCache poisoned")
+            .extend(get_live_windows());
     }
 
     fn get(&self, window_label: &str) -> Option<T> {
-        self.windows.get(window_label).cloned()
+        self.windows
+            .read()
+            .expect("WindowCache poisoned")
+            .get(window_label)
+            .cloned()
     }
 
-    fn remove(&mut self, window_label: &str) {
-        self.windows.remove(window_label);
+    fn remove(&self, window_label: &str) {
+        self.windows
+            .write()
+            .expect("WindowCache poisoned")
+            .remove(window_label);
     }
 
     fn contains(&self, window_label: &str) -> bool {
-        self.windows.contains_key(window_label)
+        self.windows
+            .read()
+            .expect("WindowCache poisoned")
+            .contains_key(window_label)
     }
 
     fn labels(&self) -> Vec<String> {
-        self.windows.keys().cloned().collect()
+        self.windows
+            .read()
+            .expect("WindowCache poisoned")
+            .keys()
+            .cloned()
+            .collect()
     }
 }
 
@@ -50,41 +75,31 @@ impl<T: Clone> WindowCache<T> {
 pub struct AppState<R: Runtime> {
     pub app: AppHandle<R>,
     pub sessions: RwLock<SessionManager>,
-    // Tauri can stop enumerating a parent WebviewWindow after it gains child webviews.
-    windows: SyncRwLock<WindowCache<WebviewWindow<R>>>,
+    windows: Arc<WindowRegistry<R>>,
 }
 
 impl<R: Runtime + 'static> AppState<R> {
-    pub fn new(app: AppHandle<R>) -> Self {
+    pub fn new(app: AppHandle<R>, windows: Arc<WindowRegistry<R>>) -> Self {
         let state = Self {
             app,
             sessions: RwLock::new(SessionManager::new()),
-            windows: SyncRwLock::new(WindowCache::new()),
+            windows,
         };
         state.refresh_windows();
         state
     }
 
     fn refresh_windows(&self) {
-        self.windows
-            .write()
-            .expect("AppState window cache poisoned")
-            .merge(self.app.webview_windows());
+        self.windows.refresh(&self.app);
     }
 
     fn get_window(&self, window_label: &str) -> Option<WebviewWindow<R>> {
         self.refresh_windows();
-        self.windows
-            .read()
-            .expect("AppState window cache poisoned")
-            .get(window_label)
+        self.windows.get(window_label)
     }
 
     pub fn remove_window_label(&self, window_label: &str) {
-        self.windows
-            .write()
-            .expect("AppState window cache poisoned")
-            .remove(window_label);
+        self.windows.remove(window_label);
     }
 
     /// Get a platform executor for a specific window by label
@@ -102,27 +117,82 @@ impl<R: Runtime + 'static> AppState<R> {
     /// Whether a window with this label has been registered
     pub fn has_window_label(&self, window_label: &str) -> bool {
         self.refresh_windows();
-        self.windows
-            .read()
-            .expect("AppState window cache poisoned")
-            .contains(window_label)
+        self.windows.contains(window_label)
     }
 
     /// Get all window labels
     pub fn get_window_labels(&self) -> Vec<String> {
         self.refresh_windows();
-        let windows = self.windows.read().expect("AppState window cache poisoned");
-        windows.labels()
+        self.windows.labels()
+    }
+}
+
+/// Retains top-level windows that Tauri stops enumerating after they gain child webviews.
+pub(crate) struct WindowRegistry<R: Runtime> {
+    windows: WindowCache<WebviewWindow<R>>,
+}
+
+impl<R: Runtime> WindowRegistry<R> {
+    pub(crate) fn new() -> Self {
+        Self {
+            windows: WindowCache::new(),
+        }
+    }
+
+    pub(crate) fn register(self: &Arc<Self>, webview: &Webview<R>) {
+        let window = webview.window();
+        if webview.label() != window.label() {
+            return;
+        }
+
+        let label = window.label().to_string();
+        let Some(webview_window) = webview.app_handle().get_webview_window(&label) else {
+            return;
+        };
+        self.merge([(label.clone(), webview_window)]);
+
+        let windows = Arc::clone(self);
+        window.on_window_event(move |event| {
+            if matches!(event, WindowEvent::Destroyed) {
+                windows.remove(&label);
+            }
+        });
+    }
+
+    fn merge(&self, live_windows: impl IntoIterator<Item = (String, WebviewWindow<R>)>) {
+        self.windows.merge(live_windows);
+    }
+
+    fn refresh(&self, app: &AppHandle<R>) {
+        self.windows.merge_with(|| app.webview_windows());
+    }
+
+    fn get(&self, window_label: &str) -> Option<WebviewWindow<R>> {
+        self.windows.get(window_label)
+    }
+
+    fn remove(&self, window_label: &str) {
+        self.windows.remove(window_label);
+    }
+
+    fn contains(&self, window_label: &str) -> bool {
+        self.windows.contains(window_label)
+    }
+
+    fn labels(&self) -> Vec<String> {
+        self.windows.labels()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::WindowCache;
+    use std::sync::{mpsc, Arc};
+    use std::thread;
 
     #[test]
     fn should_preserve_a_cached_main_window_when_live_enumeration_loses_it() {
-        let mut cached = WindowCache::new();
+        let cached = WindowCache::new();
         cached.merge([("main".to_string(), 1)]);
 
         cached.merge(std::iter::empty());
@@ -132,7 +202,7 @@ mod tests {
 
     #[test]
     fn should_remove_a_closed_window_from_the_cache() {
-        let mut cached = WindowCache::new();
+        let cached = WindowCache::new();
         cached.merge([("main".to_string(), 1)]);
 
         cached.remove("main");
@@ -142,7 +212,7 @@ mod tests {
 
     #[test]
     fn should_merge_windows_discovered_later_without_inventing_child_handles() {
-        let mut cached = WindowCache::new();
+        let cached = WindowCache::new();
         cached.merge([("main".to_string(), 1)]);
 
         cached.merge([("settings".to_string(), 2)]);
@@ -152,10 +222,36 @@ mod tests {
         assert_eq!(cached.get("settings"), Some(2));
         assert!(!cached.contains("child-webview"));
     }
+
+    #[test]
+    fn should_not_restore_a_window_removed_during_a_live_refresh() {
+        let cached = Arc::new(WindowCache::new());
+        cached.merge([("main".to_string(), 1)]);
+        let (refresh_started_tx, refresh_started_rx) = mpsc::channel();
+        let (continue_refresh_tx, continue_refresh_rx) = mpsc::channel();
+
+        let refresh_cache = Arc::clone(&cached);
+        let refresh = thread::spawn(move || {
+            refresh_cache.merge_with(|| {
+                refresh_started_tx.send(()).unwrap();
+                continue_refresh_rx.recv().unwrap();
+                [("main".to_string(), 1)]
+            });
+        });
+        refresh_started_rx.recv().unwrap();
+
+        let remove_cache = Arc::clone(&cached);
+        let remove = thread::spawn(move || remove_cache.remove("main"));
+        continue_refresh_tx.send(()).unwrap();
+
+        refresh.join().unwrap();
+        remove.join().unwrap();
+        assert!(!cached.contains("main"));
+    }
 }
 
 /// Start the `WebDriver` HTTP server on the specified port
-pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
+pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16, windows: Arc<WindowRegistry<R>>) {
     std::thread::spawn(move || {
         let rt = match TokioRuntime::new() {
             Ok(rt) => rt,
@@ -166,7 +262,7 @@ pub fn start<R: Runtime + 'static>(app: AppHandle<R>, port: u16) {
         };
 
         rt.block_on(async {
-            let state = Arc::new(AppState::new(app));
+            let state = Arc::new(AppState::new(app, windows));
             let router = router::create_router(state);
 
             // On Android, bind to all interfaces for WiFi accessibility


### PR DESCRIPTION
## Summary

- retain live top-level Tauri `WebviewWindow` executors in a dedicated cache
- remove cached executors on `close` and `Destroyed`, while keeping child WebViews out of the exposed handle set
- register cached windows before WebDriver server startup

## Root cause

Tauri's `add_child` removes the main WebView from `webview_windows`, so subsequent WebDriver lookups could no longer resolve the top-level executor after mounting a child WebView. Caching the live top-level `WebviewWindow` preserves that executor without exposing child WebViews as independent handles.

## Testing

Focused tests cover retaining top-level executors after child mount, excluding child handles, and cleanup on close/destruction. Full local Rust linking could not be completed because `link.exe` is unavailable in the local environment; CI provides the platform build and test coverage.
