### PR TITLE
fix(tauri): don't report tauri-driver missing under driverProvider 'embedded' (#618)

### DIFF
--- a/packages/tauri-service/src/diagnostics.ts
+++ b/packages/tauri-service/src/diagnostics.ts
@@ -9,6 +9,7 @@ import {
   isErr,
 } from '@wdio/native-utils';
 import { ensureTauriDriver, ensureWebKitWebDriver } from './driverManager.js';
+import { isEmbeddedProvider } from './embeddedProvider.js';
 import type { TauriServiceOptions } from './types.js';
 
 const log = createLogger('tauri-service');
@@ -47,12 +48,18 @@ export async function diagnoseTauriEnvironment(
 }
 
 async function diagnoseDriver(options: TauriServiceOptions): Promise<DiagnosticResult[]> {
-  const results: DiagnosticResult[] = [];
-  const driverOptions: TauriServiceOptions = {
-    autoInstallTauriDriver: options.autoInstallTauriDriver,
-  };
+  if (isEmbeddedProvider(options)) {
+    return [
+      {
+        category: 'Tauri Driver',
+        status: 'ok',
+        message: 'Embedded WebDriver server (tauri-plugin-wdio-webdriver) — no external driver required',
+      },
+    ];
+  }
 
-  const driverResult = await ensureTauriDriver(driverOptions);
+  const results: DiagnosticResult[] = [];
+  const driverResult = await ensureTauriDriver(options);
 
   if (isErr(driverResult)) {
     results.push({

--- a/packages/tauri-service/src/launcher.ts
+++ b/packages/tauri-service/src/launcher.ts
@@ -823,8 +823,10 @@ export default class TauriLaunchService {
       await this.ensureEmbeddedServersHealthy();
     }
 
-    // Run environment diagnostics
-    await this.diagnoseEnvironment(this.appBinaryPath);
+    await this.diagnoseEnvironment(
+      this.appBinaryPath,
+      mergeOptions(this.options, firstCap['wdio:tauriServiceOptions']),
+    );
 
     log.debug(`Tauri worker session started: ${cid}`);
   }
@@ -903,10 +905,8 @@ export default class TauriLaunchService {
   /**
    * Diagnose the environment before running tests
    */
-  private async diagnoseEnvironment(binaryPath: string): Promise<void> {
-    const results = await diagnoseTauriEnvironment(binaryPath, {
-      autoInstallTauriDriver: this.options.autoInstallTauriDriver,
-    });
+  private async diagnoseEnvironment(binaryPath: string, options: TauriServiceOptions): Promise<void> {
+    const results = await diagnoseTauriEnvironment(binaryPath, options);
     formatDiagnosticResults(results);
   }
 

--- a/packages/tauri-service/test/diagnostics.spec.ts
+++ b/packages/tauri-service/test/diagnostics.spec.ts
@@ -1,0 +1,95 @@
+import { Err, Ok } from '@wdio/native-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { diagnoseTauriEnvironment } from '../src/diagnostics.js';
+import { ensureTauriDriver, ensureWebKitWebDriver } from '../src/driverManager.js';
+import type { TauriServiceOptions } from '../src/types.js';
+
+// Stub only the noisy, platform-dependent environment probes.
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return {
+    ...actual,
+    diagnosePlatform: () => [],
+    diagnoseDisplay: () => [],
+    diagnoseBinary: () => [],
+    diagnoseLinuxDependencies: () => [],
+    diagnoseDiskSpace: () => [],
+  };
+});
+
+vi.mock('../src/driverManager.js', () => ({
+  ensureTauriDriver: vi.fn(),
+  ensureWebKitWebDriver: vi.fn(),
+}));
+
+const BINARY = '/fake/app';
+
+function tauriDriverResult(results: Awaited<ReturnType<typeof diagnoseTauriEnvironment>>) {
+  return results.find((r) => r.category === 'Tauri Driver');
+}
+
+describe('diagnoseTauriEnvironment - driver check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ensureWebKitWebDriver).mockResolvedValue(Ok({}));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should report the embedded server as OK without probing for the external driver', async () => {
+    const options: TauriServiceOptions = { driverProvider: 'embedded' };
+
+    const result = tauriDriverResult(await diagnoseTauriEnvironment(BINARY, options));
+
+    expect(result?.status).toBe('ok');
+    expect(result?.message).toContain('Embedded WebDriver server');
+    expect(ensureTauriDriver).not.toHaveBeenCalled();
+  });
+
+  it('should treat an omitted driverProvider as embedded (the default) and not probe', async () => {
+    const options: TauriServiceOptions = {};
+
+    const result = tauriDriverResult(await diagnoseTauriEnvironment(BINARY, options));
+
+    expect(result?.status).toBe('ok');
+    expect(result?.message).toContain('Embedded WebDriver server');
+    expect(ensureTauriDriver).not.toHaveBeenCalled();
+  });
+
+  it('should report OK for the external provider when the driver is found', async () => {
+    vi.mocked(ensureTauriDriver).mockResolvedValue(Ok({ path: '/usr/local/bin/tauri-driver', method: 'found' }));
+    const options: TauriServiceOptions = { driverProvider: 'external', autoInstallTauriDriver: true };
+
+    const result = tauriDriverResult(await diagnoseTauriEnvironment(BINARY, options));
+
+    expect(result?.status).toBe('ok');
+    expect(result?.message).toBe('/usr/local/bin/tauri-driver (found)');
+  });
+
+  it('should report an error for the external provider when the driver is missing', async () => {
+    vi.mocked(ensureTauriDriver).mockResolvedValue(
+      Err(new Error('tauri-driver not found. Install it with: cargo install tauri-driver')),
+    );
+    const options: TauriServiceOptions = { driverProvider: 'external' };
+
+    const result = tauriDriverResult(await diagnoseTauriEnvironment(BINARY, options));
+
+    expect(result?.status).toBe('error');
+    expect(result?.message).toContain('tauri-driver not found');
+  });
+
+  it('should forward the configured provider and driver paths to ensureTauriDriver', async () => {
+    vi.mocked(ensureTauriDriver).mockResolvedValue(Ok({ path: '/cn/tauri-driver', method: 'found' }));
+    const options: TauriServiceOptions = {
+      driverProvider: 'crabnebula',
+      crabnebulaDriverPath: '/cn/tauri-driver',
+      autoInstallTauriDriver: false,
+    };
+
+    await diagnoseTauriEnvironment(BINARY, options);
+
+    expect(ensureTauriDriver).toHaveBeenCalledWith(expect.objectContaining(options));
+  });
+});


### PR DESCRIPTION
## What & why

Fixes #618.

With `driverProvider: 'embedded'`, every worker start logged a spurious `ERROR`:

```
ERROR diagnostics: ❌ Tauri Driver: tauri-driver not found. Install it with: cargo install tauri-driver
```

The embedded provider runs the WebDriver server **inside the app process** (`tauri-plugin-wdio-webdriver`) and never spawns the external `tauri-driver` binary, so the check does not apply. The run itself was always unaffected — the diagnostic is only logged — but an `ERROR` line in CI logs reads as the cause of any failure sharing the same run, costing triage time.

### Root cause

Two places dropped the provider context:

- `launcher.ts` passed only `{ autoInstallTauriDriver }` into `diagnoseTauriEnvironment()`.
- `diagnostics.ts` `diagnoseDriver()` forwarded only that field, so `ensureTauriDriver()` fell back to `options.driverProvider ?? 'external'` and probed the filesystem for `tauri-driver` regardless of the configured provider.

This also mis-reported **`crabnebula`** and **custom-path** setups (they'd fail the check even when correctly configured), not just `embedded`.

### Fix

- **`launcher.ts`** — forward the effective (global + capability) options into the driver diagnostic via `mergeOptions(...)`.
- **`diagnostics.ts`** — short-circuit the `'embedded'` provider with an `ok` result (`Embedded WebDriver server (tauri-plugin-wdio-webdriver) — no external driver required`), and forward the full options to `ensureTauriDriver()` so `crabnebula`/custom-path providers are honoured.

No behavioural change to the actual run path — `onPrepare` already skips `ensureTauriDriver` for the embedded provider. This only removes the false diagnostic.

## Testing

- New `test/diagnostics.spec.ts` (4 cases): embedded reports OK without probing for the binary; external reports OK/error as before; full provider context (provider + custom paths) is forwarded to `ensureTauriDriver`.
- `pnpm --filter @wdio/tauri-service test` — **655 passed** (33 files).
- `pnpm --filter @wdio/tauri-service typecheck` — clean.
- `biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)