### PR TITLE
fix(diagnostics): resolve Linux deps by soname via ldconfig, not dpkg package names (#617)

### DIFF
--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -147,7 +147,7 @@ if [ -z "$LDCONFIG_BIN" ]; then
 elif ! "$LDCONFIG_BIN" -p 2>/dev/null | grep -q 'libgtk-3\.so\.0'; then
     echo 'SKIP: libgtk-3.so.0 not in ldconfig cache; cannot run guard'
 elif grep -Eq 'Missing:.*libgtk-3\.so\.0' /workspace/logs-output/wdio-run.log; then
-    echo 'FAIL: libgtk-3.so.0 is installed but the diagnostic reported it missing (issue #617 regression)'
+    echo 'FAIL: libgtk-3.so.0 is installed but the diagnostic reported it missing'
     TEST_EXIT=1
 else
     echo 'OK: installed libgtk-3.so.0 was not falsely reported missing'

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -130,8 +130,8 @@ npx tauri build --debug
 echo '=== Running Tauri package test ==='
 # Capture the exit code instead of letting set -e abort here, so the wdio
 # session logs are still copied out on failure -- that is exactly when they
-# are needed. Tee to a file so the #617 guard below can inspect the launcher's
-# diagnostic output (PIPESTATUS[0] is wdio's code, not tee's).
+# are needed. Tee to a log the guard below greps; PIPESTATUS[0] is wdio's
+# exit code, not tee's.
 set +e
 npx wdio run wdio.conf.ts 2>&1 | tee /workspace/logs-output/wdio-run.log
 TEST_EXIT=${PIPESTATUS[0]}

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -130,11 +130,34 @@ npx tauri build --debug
 echo '=== Running Tauri package test ==='
 # Capture the exit code instead of letting set -e abort here, so the wdio
 # session logs are still copied out on failure -- that is exactly when they
-# are needed.
+# are needed. Tee to a file so the #617 guard below can inspect the launcher's
+# diagnostic output (PIPESTATUS[0] is wdio's code, not tee's).
 set +e
-npx wdio run wdio.conf.ts
-TEST_EXIT=$?
+npx wdio run wdio.conf.ts 2>&1 | tee /workspace/logs-output/wdio-run.log
+TEST_EXIT=${PIPESTATUS[0]}
 set -e
+
+# Regression guard for issue #617: the Linux-dependency diagnostic must not
+# report an installed system library as missing. libgtk-3.so.0 is always present
+# in a Tauri container (system WebKitGTK depends on GTK 3), so if it appears in
+# the diagnostic's "Missing:" list the soname check has false-positived -- which
+# is exactly what the old dpkg name check did on the Debian/Ubuntu t64 rename and
+# on every non-dpkg distro (fedora/arch/void).
+echo '=== Regression guard (issue #617): installed libraries must not be reported missing ==='
+LDCONFIG_BIN=''
+for c in ldconfig /usr/sbin/ldconfig /sbin/ldconfig; do
+    if command -v "$c" > /dev/null 2>&1; then LDCONFIG_BIN="$c"; break; fi
+done
+if [ -z "$LDCONFIG_BIN" ]; then
+    echo 'SKIP: no ldconfig found; cannot run #617 guard'
+elif ! "$LDCONFIG_BIN" -p 2>/dev/null | grep -q 'libgtk-3\.so\.0'; then
+    echo 'SKIP: libgtk-3.so.0 not in ldconfig cache; cannot run #617 guard'
+elif grep -Eq 'Missing:.*libgtk-3\.so\.0' /workspace/logs-output/wdio-run.log; then
+    echo 'FAIL: libgtk-3.so.0 is installed but the diagnostic reported it missing (issue #617 regression)'
+    TEST_EXIT=1
+else
+    echo 'OK: installed libgtk-3.so.0 was not falsely reported missing'
+fi
 
 echo '=== Copying logs to mounted volume ==='
 # Absolute path: CWD is the app dir at this point, so a repo-relative

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -136,21 +136,16 @@ npx wdio run wdio.conf.ts 2>&1 | tee /workspace/logs-output/wdio-run.log
 TEST_EXIT=${PIPESTATUS[0]} # wdio's exit code
 set -e
 
-# Regression guard for issue #617: the Linux-dependency diagnostic must not
-# report an installed system library as missing. libgtk-3.so.0 is always present
-# in a Tauri container (system WebKitGTK depends on GTK 3), so if it appears in
-# the diagnostic's "Missing:" list the soname check has false-positived -- which
-# is exactly what the old dpkg name check did on the Debian/Ubuntu t64 rename and
-# on every non-dpkg distro (fedora/arch/void).
-echo '=== Regression guard (issue #617): installed libraries must not be reported missing ==='
+# libgtk-3.so.0 is guaranteed present in a Tauri container (WebKitGTK needs GTK 3).
+echo '=== Regression guard: installed libraries must not be reported missing ==='
 LDCONFIG_BIN=''
 for c in ldconfig /usr/sbin/ldconfig /sbin/ldconfig; do
     if command -v "$c" > /dev/null 2>&1; then LDCONFIG_BIN="$c"; break; fi
 done
 if [ -z "$LDCONFIG_BIN" ]; then
-    echo 'SKIP: no ldconfig found; cannot run #617 guard'
+    echo 'SKIP: no ldconfig found; cannot run guard'
 elif ! "$LDCONFIG_BIN" -p 2>/dev/null | grep -q 'libgtk-3\.so\.0'; then
-    echo 'SKIP: libgtk-3.so.0 not in ldconfig cache; cannot run #617 guard'
+    echo 'SKIP: libgtk-3.so.0 not in ldconfig cache; cannot run guard'
 elif grep -Eq 'Missing:.*libgtk-3\.so\.0' /workspace/logs-output/wdio-run.log; then
     echo 'FAIL: libgtk-3.so.0 is installed but the diagnostic reported it missing (issue #617 regression)'
     TEST_EXIT=1

--- a/fixtures/package-tests/tauri-app/docker/container-test.sh
+++ b/fixtures/package-tests/tauri-app/docker/container-test.sh
@@ -130,11 +130,10 @@ npx tauri build --debug
 echo '=== Running Tauri package test ==='
 # Capture the exit code instead of letting set -e abort here, so the wdio
 # session logs are still copied out on failure -- that is exactly when they
-# are needed. Tee to a log the guard below greps; PIPESTATUS[0] is wdio's
-# exit code, not tee's.
+# are needed.
 set +e
 npx wdio run wdio.conf.ts 2>&1 | tee /workspace/logs-output/wdio-run.log
-TEST_EXIT=${PIPESTATUS[0]}
+TEST_EXIT=${PIPESTATUS[0]} # wdio's exit code
 set -e
 
 # Regression guard for issue #617: the Linux-dependency diagnostic must not

--- a/packages/electron-service/src/diagnostics.ts
+++ b/packages/electron-service/src/diagnostics.ts
@@ -6,24 +6,25 @@ import {
   diagnoseDisplay,
   diagnoseLinuxDependencies,
   diagnosePlatform,
+  type LinuxLibrary,
 } from '@wdio/native-utils';
 
 const log = createLogger('electron-service');
 
-const ELECTRON_LINUX_PACKAGES = [
-  'libgtk-3-0',
-  'libgbm1',
-  'libasound2',
-  'libatk-bridge2.0-0',
-  'libcups2',
-  'libdrm2',
-  'libxkbcommon0',
-  'libxcomposite1',
-  'libxdamage1',
-  'libxrandr2',
-  'libnss3',
-  'libnspr4',
-  'libatk1.0-0',
+const ELECTRON_LINUX_LIBRARIES: LinuxLibrary[] = [
+  { soname: 'libgtk-3.so.0', aptPackage: 'libgtk-3-0' },
+  { soname: 'libgbm.so.1', aptPackage: 'libgbm1' },
+  { soname: 'libasound.so.2', aptPackage: 'libasound2' },
+  { soname: 'libatk-bridge-2.0.so.0', aptPackage: 'libatk-bridge2.0-0' },
+  { soname: 'libcups.so.2', aptPackage: 'libcups2' },
+  { soname: 'libdrm.so.2', aptPackage: 'libdrm2' },
+  { soname: 'libxkbcommon.so.0', aptPackage: 'libxkbcommon0' },
+  { soname: 'libXcomposite.so.1', aptPackage: 'libxcomposite1' },
+  { soname: 'libXdamage.so.1', aptPackage: 'libxdamage1' },
+  { soname: 'libXrandr.so.2', aptPackage: 'libxrandr2' },
+  { soname: 'libnss3.so', aptPackage: 'libnss3' },
+  { soname: 'libnspr4.so', aptPackage: 'libnspr4' },
+  { soname: 'libatk-1.0.so.0', aptPackage: 'libatk1.0-0' },
 ];
 
 export interface ElectronDiagnosticsOptions {
@@ -54,7 +55,7 @@ export async function diagnoseElectronEnvironment(
     results.push(...diagnoseChromiumVersion(options.chromiumVersion));
   }
 
-  results.push(...diagnoseLinuxDependencies(ELECTRON_LINUX_PACKAGES));
+  results.push(...diagnoseLinuxDependencies(ELECTRON_LINUX_LIBRARIES));
   results.push(...diagnoseDiskSpace());
 
   log.debug('Diagnostics complete');

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -153,11 +153,38 @@ export interface LinuxLibrary {
 // only reads the cache, so it needs no privileges — we just have to find it.
 const LDCONFIG_CANDIDATES = ['ldconfig', '/usr/sbin/ldconfig', '/sbin/ldconfig'];
 
+// A cache entry: `<soname> (<abi tags>) => <path>`, e.g.
+// `libcups.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcups.so.2`.
+const LDCONFIG_ENTRY = /^(\S+\.so\S*)\s+\(([^)]*)\)/;
+
 /**
- * Read the shared-library cache (`ldconfig -p`) into a set of sonames, or
- * `undefined` when no `ldconfig` is available (musl/Alpine, minimal containers).
+ * The `ldconfig` ABI tag for the running architecture, or `undefined` when we
+ * don't map it. Used to ignore libraries present only for a *foreign*
+ * architecture on a multiarch host — those can't be loaded by the app's native
+ * binary. Only the architectures we ship on are mapped; on anything else we
+ * don't filter, so an unrecognised tag can never turn an installed library into
+ * a false "missing".
  */
-function readSharedLibraryCache(): Set<string> | undefined {
+function hostArchTag(): string | undefined {
+  const tags: Partial<Record<NodeJS.Architecture, string>> = { x64: 'x86-64', arm64: 'aarch64' };
+  return tags[process.arch];
+}
+
+type LibraryCache =
+  | { status: 'ok'; sonames: Set<string> }
+  | { status: 'unavailable' } // no `ldconfig` binary found
+  | { status: 'error'; message: string }; // `ldconfig` present but failed to run
+
+/**
+ * Read the shared-library cache (`ldconfig -p`) into a set of sonames for the
+ * host architecture. Distinguishes "no `ldconfig`" (musl/Alpine, minimal
+ * containers) from "`ldconfig` present but failed" (timeout, permissions) so
+ * the caller doesn't report an operational failure as a passing check.
+ */
+function readSharedLibraryCache(): LibraryCache {
+  const archTag = hostArchTag();
+  let operationalError: string | undefined;
+
   for (const bin of LDCONFIG_CANDIDATES) {
     try {
       const output = execFileSync(bin, ['-p'], {
@@ -167,18 +194,28 @@ function readSharedLibraryCache(): Set<string> | undefined {
       });
       const sonames = new Set<string>();
       for (const line of output.split('\n')) {
-        // e.g. `\tlibcups.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcups.so.2`
-        const soname = line.trim().split(' ')[0];
-        if (soname.includes('.so')) {
+        const match = line.trim().match(LDCONFIG_ENTRY);
+        if (!match) {
+          continue;
+        }
+        const [, soname, tags] = match;
+        if (!archTag || tags.toLowerCase().includes(archTag)) {
           sonames.add(soname);
         }
       }
-      return sonames;
-    } catch {
-      // Try the next candidate path; fall through to undefined if none work.
+      return { status: 'ok', sonames };
+    } catch (error) {
+      // ENOENT just means this path isn't the binary — try the next candidate.
+      // Any other failure (timeout, EACCES, non-zero exit) means `ldconfig` is
+      // present but couldn't run: remember it so we surface it rather than let
+      // an operational failure masquerade as "not installed".
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        operationalError = error instanceof Error ? error.message : String(error);
+      }
     }
   }
-  return undefined;
+
+  return operationalError ? { status: 'error', message: operationalError } : { status: 'unavailable' };
 }
 
 /**
@@ -197,19 +234,33 @@ export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): Diagnostic
   }
 
   const cache = readSharedLibraryCache();
-  if (!cache) {
-    // Without the cache we can't tell present from missing — skip rather than
-    // emit false "missing" warnings on systems that lack `ldconfig`.
+
+  if (cache.status === 'unavailable') {
+    // No `ldconfig` at all (musl/Alpine, minimal images) — we genuinely can't
+    // check, so skip quietly rather than emit false "missing" warnings.
     return [
       {
         category: 'Linux Dependencies',
         status: 'ok',
-        message: 'Skipped — shared-library cache (ldconfig) unavailable',
+        message: 'Skipped — ldconfig not available',
       },
     ];
   }
 
-  const missing = libraries.filter((lib) => !cache.has(lib.soname));
+  if (cache.status === 'error') {
+    // `ldconfig` exists but failed (timeout, permissions, …). Surface it as a
+    // warning so a genuinely missing dependency isn't silently marked ok.
+    return [
+      {
+        category: 'Linux Dependencies',
+        status: 'warn',
+        message: 'Could not check Linux dependencies',
+        details: `ldconfig failed: ${cache.message}`,
+      },
+    ];
+  }
+
+  const missing = libraries.filter((lib) => !cache.sonames.has(lib.soname));
 
   if (missing.length > 0) {
     const sonames = missing.map((lib) => lib.soname).join(', ');

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -236,8 +236,7 @@ export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): Diagnostic
   const cache = readSharedLibraryCache();
 
   if (cache.status === 'unavailable') {
-    // No `ldconfig` at all (musl/Alpine, minimal images) — skip quietly rather
-    // than emit false "missing" warnings.
+    // No `ldconfig` at all (musl/Alpine, minimal images).
     return [
       {
         category: 'Linux Dependencies',
@@ -248,8 +247,7 @@ export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): Diagnostic
   }
 
   if (cache.status === 'error') {
-    // `ldconfig` exists but failed (timeout, permissions, …). Surface it as a
-    // warning so a genuinely missing dependency isn't silently marked ok.
+    // `ldconfig` exists but failed (timeout, permissions, …).
     return [
       {
         category: 'Linux Dependencies',

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -221,12 +221,7 @@ function readSharedLibraryCache(): LibraryCache {
 /**
  * Check that each library's soname is resolvable via the `ldconfig` cache.
  *
- * Checks sonames rather than package names on purpose: package names drift
- * across distros and transitions (the Debian/Ubuntu 64-bit `time_t` rename that
- * turned `libcups2` into `libcups2t64`, issue #617), but the soname
- * (`libcups.so.2`) is unchanged and is what the app actually dlopens. It also
- * frees the check from any one package manager, so it works the same on
- * dpkg, rpm, pacman and xbps systems.
+ * Sonames work across distros and, unlike package names, don't drift (#617).
  */
 export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): DiagnosticResult[] {
   if (process.platform !== 'linux') {
@@ -247,7 +242,7 @@ export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): Diagnostic
   }
 
   if (cache.status === 'error') {
-    // `ldconfig` exists but failed (timeout, permissions, …).
+    // `ldconfig` exists but failed.
     return [
       {
         category: 'Linux Dependencies',

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -143,7 +143,7 @@ export function diagnoseSharedLibraries(binaryPath: string): DiagnosticResult[] 
 
 /**
  * A shared library the app needs. We check sonames, not package names, because
- * sonames work across distros and don't drift the way package names do (see
+ * sonames work across distros and don't drift like package names (see
  * https://github.com/webdriverio/desktop-mobile/issues/617). `aptPackage` is
  * only for the Debian/Ubuntu install hint.
  */
@@ -160,14 +160,6 @@ const LDCONFIG_CANDIDATES = ['ldconfig', '/usr/sbin/ldconfig', '/sbin/ldconfig']
 // `libcups.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcups.so.2`.
 const LDCONFIG_ENTRY = /^(\S+\.so\S*)\s+\(([^)]*)\)/;
 
-/**
- * The `ldconfig` ABI tag for the running architecture, or `undefined` when we
- * don't map it. Used to ignore libraries present only for a *foreign*
- * architecture on a multiarch host — those can't be loaded by the app's native
- * binary. Only the architectures we ship on are mapped; on anything else we
- * don't filter, so an unrecognised tag can never turn an installed library into
- * a false "missing".
- */
 function hostArchTag(): string | undefined {
   const tags: Partial<Record<NodeJS.Architecture, string>> = { x64: 'x86-64', arm64: 'aarch64' };
   return tags[process.arch];
@@ -196,6 +188,8 @@ function readSharedLibraryCache(): LibraryCache {
           continue;
         }
         const [, soname, tags] = match;
+        // Only count a soname built for the host arch — a foreign-arch copy on
+        // a multiarch host can't be loaded.
         if (!archTag || tags.toLowerCase().includes(archTag)) {
           sonames.add(soname);
         }

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -188,8 +188,7 @@ function readSharedLibraryCache(): LibraryCache {
           continue;
         }
         const [, soname, tags] = match;
-        // Only count a soname built for the host arch — a foreign-arch copy on
-        // a multiarch host can't be loaded.
+        // A soname present only for a foreign arch (multiarch host) can't be loaded.
         if (!archTag || tags.toLowerCase().includes(archTag)) {
           sonames.add(soname);
         }

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -153,7 +153,7 @@ export interface LinuxLibrary {
 }
 
 // `ldconfig` lives in /sbin or /usr/sbin (often off a non-root PATH) on
-// Debian/Ubuntu/Fedora and in /usr/bin on usr-merged Arch/Void.
+// Debian/Ubuntu/Fedora and in /usr/bin on Arch/Void.
 const LDCONFIG_CANDIDATES = ['ldconfig', '/usr/sbin/ldconfig', '/sbin/ldconfig'];
 
 // A cache entry: `<soname> (<abi tags>) => <path>`, e.g.

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -236,8 +236,8 @@ export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): Diagnostic
   const cache = readSharedLibraryCache();
 
   if (cache.status === 'unavailable') {
-    // No `ldconfig` at all (musl/Alpine, minimal images) — we genuinely can't
-    // check, so skip quietly rather than emit false "missing" warnings.
+    // No `ldconfig` at all (musl/Alpine, minimal images) — skip quietly rather
+    // than emit false "missing" warnings.
     return [
       {
         category: 'Linux Dependencies',

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -141,38 +141,96 @@ export function diagnoseSharedLibraries(binaryPath: string): DiagnosticResult[] 
   return results;
 }
 
-export function diagnoseLinuxDependencies(requiredPackages: string[]): DiagnosticResult[] {
+export interface LinuxLibrary {
+  /** Runtime soname to look up in the shared-library cache, e.g. `libcups.so.2`. */
+  soname: string;
+  /** Debian/Ubuntu package that provides it — used only for the install hint. */
+  aptPackage: string;
+}
+
+// `ldconfig` lives in /sbin or /usr/sbin (often off a non-root PATH) on
+// Debian/Ubuntu/Fedora and in /usr/bin on usr-merged Arch/Void. `ldconfig -p`
+// only reads the cache, so it needs no privileges — we just have to find it.
+const LDCONFIG_CANDIDATES = ['ldconfig', '/usr/sbin/ldconfig', '/sbin/ldconfig'];
+
+/**
+ * Read the shared-library cache (`ldconfig -p`) into a set of sonames, or
+ * `undefined` when no `ldconfig` is available (musl/Alpine, minimal containers).
+ */
+function readSharedLibraryCache(): Set<string> | undefined {
+  for (const bin of LDCONFIG_CANDIDATES) {
+    try {
+      const output = execFileSync(bin, ['-p'], {
+        encoding: 'utf8',
+        timeout: 2000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const sonames = new Set<string>();
+      for (const line of output.split('\n')) {
+        // e.g. `\tlibcups.so.2 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcups.so.2`
+        const soname = line.trim().split(' ')[0];
+        if (soname.includes('.so')) {
+          sonames.add(soname);
+        }
+      }
+      return sonames;
+    } catch {
+      // Try the next candidate path; fall through to undefined if none work.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Check that each library's soname is resolvable via the `ldconfig` cache.
+ *
+ * Checks sonames rather than package names on purpose: package names drift
+ * across distros and transitions (the Debian/Ubuntu 64-bit `time_t` rename that
+ * turned `libcups2` into `libcups2t64`, issue #617), but the soname
+ * (`libcups.so.2`) is unchanged and is what the app actually dlopens. It also
+ * frees the check from any one package manager, so it works the same on
+ * dpkg, rpm, pacman and xbps systems.
+ */
+export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): DiagnosticResult[] {
   if (process.platform !== 'linux') {
     return [];
   }
 
-  const results: DiagnosticResult[] = [];
-  const missing: string[] = [];
-
-  for (const pkg of requiredPackages) {
-    try {
-      execFileSync('dpkg', ['-s', pkg], { timeout: 1000, stdio: 'ignore' });
-    } catch {
-      missing.push(pkg);
-    }
+  const cache = readSharedLibraryCache();
+  if (!cache) {
+    // Without the cache we can't tell present from missing — skip rather than
+    // emit false "missing" warnings on systems that lack `ldconfig`.
+    return [
+      {
+        category: 'Linux Dependencies',
+        status: 'ok',
+        message: 'Skipped — shared-library cache (ldconfig) unavailable',
+      },
+    ];
   }
+
+  const missing = libraries.filter((lib) => !cache.has(lib.soname));
 
   if (missing.length > 0) {
-    results.push({
-      category: 'Linux Dependencies',
-      status: 'warn',
-      message: `${missing.length} packages may be missing`,
-      details: `Missing: ${missing.join(', ')}\nInstall with: sudo apt-get install ${missing.join(' ')}`,
-    });
-  } else {
-    results.push({
-      category: 'Linux Dependencies',
-      status: 'ok',
-      message: 'All required packages installed',
-    });
+    const sonames = missing.map((lib) => lib.soname).join(', ');
+    const packages = missing.map((lib) => lib.aptPackage).join(' ');
+    return [
+      {
+        category: 'Linux Dependencies',
+        status: 'warn',
+        message: `${missing.length} librar${missing.length === 1 ? 'y' : 'ies'} may be missing`,
+        details: `Missing: ${sonames}\nOn Debian/Ubuntu, install with: sudo apt-get install ${packages}`,
+      },
+    ];
   }
 
-  return results;
+  return [
+    {
+      category: 'Linux Dependencies',
+      status: 'ok',
+      message: 'All required libraries found',
+    },
+  ];
 }
 
 export function diagnoseDiskSpace(): DiagnosticResult[] {

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -177,9 +177,7 @@ type LibraryCache =
 
 /**
  * Read the shared-library cache (`ldconfig -p`) into a set of sonames for the
- * host architecture. Distinguishes "no `ldconfig`" (musl/Alpine, minimal
- * containers) from "`ldconfig` present but failed" (timeout, permissions) so
- * the caller doesn't report an operational failure as a passing check.
+ * host architecture.
  */
 function readSharedLibraryCache(): LibraryCache {
   const archTag = hostArchTag();
@@ -206,9 +204,6 @@ function readSharedLibraryCache(): LibraryCache {
       return { status: 'ok', sonames };
     } catch (error) {
       // ENOENT just means this path isn't the binary — try the next candidate.
-      // Any other failure (timeout, EACCES, non-zero exit) means `ldconfig` is
-      // present but couldn't run: remember it so we surface it rather than let
-      // an operational failure masquerade as "not installed".
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         operationalError = error instanceof Error ? error.message : String(error);
       }

--- a/packages/native-utils/src/diagnostics.ts
+++ b/packages/native-utils/src/diagnostics.ts
@@ -141,16 +141,19 @@ export function diagnoseSharedLibraries(binaryPath: string): DiagnosticResult[] 
   return results;
 }
 
+/**
+ * A shared library the app needs. We check sonames, not package names, because
+ * sonames work across distros and don't drift the way package names do (see
+ * https://github.com/webdriverio/desktop-mobile/issues/617). `aptPackage` is
+ * only for the Debian/Ubuntu install hint.
+ */
 export interface LinuxLibrary {
-  /** Runtime soname to look up in the shared-library cache, e.g. `libcups.so.2`. */
   soname: string;
-  /** Debian/Ubuntu package that provides it — used only for the install hint. */
   aptPackage: string;
 }
 
 // `ldconfig` lives in /sbin or /usr/sbin (often off a non-root PATH) on
-// Debian/Ubuntu/Fedora and in /usr/bin on usr-merged Arch/Void. `ldconfig -p`
-// only reads the cache, so it needs no privileges — we just have to find it.
+// Debian/Ubuntu/Fedora and in /usr/bin on usr-merged Arch/Void.
 const LDCONFIG_CANDIDATES = ['ldconfig', '/usr/sbin/ldconfig', '/sbin/ldconfig'];
 
 // A cache entry: `<soname> (<abi tags>) => <path>`, e.g.
@@ -175,10 +178,6 @@ type LibraryCache =
   | { status: 'unavailable' } // no `ldconfig` binary found
   | { status: 'error'; message: string }; // `ldconfig` present but failed to run
 
-/**
- * Read the shared-library cache (`ldconfig -p`) into a set of sonames for the
- * host architecture.
- */
 function readSharedLibraryCache(): LibraryCache {
   const archTag = hostArchTag();
   let operationalError: string | undefined;
@@ -213,11 +212,6 @@ function readSharedLibraryCache(): LibraryCache {
   return operationalError ? { status: 'error', message: operationalError } : { status: 'unavailable' };
 }
 
-/**
- * Check that each library's soname is resolvable via the `ldconfig` cache.
- *
- * Sonames work across distros and, unlike package names, don't drift (#617).
- */
 export function diagnoseLinuxDependencies(libraries: LinuxLibrary[]): DiagnosticResult[] {
   if (process.platform !== 'linux') {
     return [];

--- a/packages/native-utils/src/index.ts
+++ b/packages/native-utils/src/index.ts
@@ -11,6 +11,7 @@ export {
   diagnosePlatform,
   diagnoseSharedLibraries,
   formatDiagnosticResults,
+  type LinuxLibrary,
 } from './diagnostics.js';
 export type { LogArea } from './log.js';
 export { type NormalizedReadResult, readPackageUp, readPackageUpSync } from './package.js';

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -19,6 +19,10 @@ const setPlatform = (platform: NodeJS.Platform): void => {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 };
 
+const setArch = (arch: NodeJS.Architecture): void => {
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+};
+
 const stubMode = (mode: number, size = 100 * 1024 * 1024): void => {
   vi.mocked(statSync).mockReturnValue({ mode, size } as unknown as ReturnType<typeof statSync>);
 };
@@ -63,11 +67,17 @@ const LIBS: LinuxLibrary[] = [
   { soname: 'libnss3.so', aptPackage: 'libnss3' },
 ];
 
+// The ldconfig ABI tag for the running arch, so mock entries survive the
+// arch filter on whatever host runs the tests (x64 or arm64; anything else is
+// unfiltered, so the tag is irrelevant there).
+const hostArchTag = (): string =>
+  (({ x64: 'x86-64', arm64: 'aarch64' }) as Record<string, string>)[process.arch] ?? 'x86-64';
+
 // Mimic `ldconfig -p`: a header line then one tab-indented entry per soname.
-const ldconfigCache = (sonames: string[]): string =>
+const ldconfigCache = (sonames: string[], archTag = hostArchTag()): string =>
   [
     `${sonames.length} libs found in the cache \`/etc/ld.so.cache'`,
-    ...sonames.map((s) => `\t${s} (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/${s}`),
+    ...sonames.map((s) => `\t${s} (libc6,${archTag}) => /usr/lib/${archTag}-linux-gnu/${s}`),
   ].join('\n');
 
 const linuxDeps = (libs: LinuxLibrary[]) =>
@@ -75,9 +85,11 @@ const linuxDeps = (libs: LinuxLibrary[]) =>
 
 describe('diagnoseLinuxDependencies', () => {
   const realPlatform = process.platform;
+  const realArch = process.arch;
 
   afterEach(() => {
     setPlatform(realPlatform);
+    setArch(realArch);
     vi.clearAllMocks();
   });
 
@@ -130,5 +142,33 @@ describe('diagnoseLinuxDependencies', () => {
       return ldconfigCache(LIBS.map((l) => l.soname));
     });
     expect(linuxDeps(LIBS)?.status).toBe('ok');
+  });
+
+  it('does not count a library present only for a foreign architecture as found', () => {
+    setPlatform('linux');
+    setArch('x64');
+    // Every soname is in the cache, but tagged for aarch64 only — an x64 binary
+    // cannot load them, so they must be reported missing, not found.
+    vi.mocked(execFileSync).mockReturnValue(
+      ldconfigCache(
+        LIBS.map((l) => l.soname),
+        'aarch64',
+      ),
+    );
+    const result = linuxDeps(LIBS);
+    expect(result?.status).toBe('warn');
+    expect(result?.details).toContain('libcups.so.2');
+  });
+
+  it('warns (not ok) when ldconfig is present but fails to run', () => {
+    setPlatform('linux');
+    // Non-ENOENT failure (e.g. a timeout) means ldconfig exists but could not
+    // run — that must surface as a warning, not a silent passing check.
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('spawnSync /usr/sbin/ldconfig ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    });
+    const result = linuxDeps(LIBS);
+    expect(result?.status).toBe('warn');
+    expect(result?.message).toMatch(/could not check/i);
   });
 });

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -59,8 +59,7 @@ describe('diagnoseBinary', () => {
 });
 
 // A representative subset — the check is list-agnostic, so the shape matters,
-// not the exact members. libcups.so.2 is the #617 poster child (its package,
-// libcups2, becomes libcups2t64 on Debian Trixie / Ubuntu 24.04+).
+// not the exact members.
 const LIBS: LinuxLibrary[] = [
   { soname: 'libgtk-3.so.0', aptPackage: 'libgtk-3-0' },
   { soname: 'libcups.so.2', aptPackage: 'libcups2' },

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -73,7 +73,7 @@ const LIBS: LinuxLibrary[] = [
 const hostArchTag = (): string =>
   (({ x64: 'x86-64', arm64: 'aarch64' }) as Record<string, string>)[process.arch] ?? 'x86-64';
 
-// Mimic `ldconfig -p`: a header line then one tab-indented entry per soname.
+// Mimic `ldconfig -p` output.
 const ldconfigCache = (sonames: string[], archTag = hostArchTag()): string =>
   [
     `${sonames.length} libs found in the cache \`/etc/ld.so.cache'`,
@@ -93,18 +93,18 @@ describe('diagnoseLinuxDependencies', () => {
     vi.clearAllMocks();
   });
 
-  it('returns nothing on non-Linux platforms', () => {
+  it('should return nothing on non-Linux platforms', () => {
     setPlatform('darwin');
     expect(diagnoseLinuxDependencies(LIBS)).toEqual([]);
   });
 
-  it('reports ok when every soname resolves in the ldconfig cache', () => {
+  it('should report ok when every soname resolves in the ldconfig cache', () => {
     setPlatform('linux');
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 
-  it('does not false-warn on the Debian/Ubuntu t64 package rename (issue #617)', () => {
+  it('should not false-warn on the Debian/Ubuntu t64 package rename (issue #617)', () => {
     setPlatform('linux');
     // Package is libcups2t64, but the soname libcups.so.2 is unchanged, so the
     // cache still lists it — the check must pass with no warning.
@@ -112,7 +112,7 @@ describe('diagnoseLinuxDependencies', () => {
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 
-  it('warns and names the missing soname and its apt package', () => {
+  it('should warn and name the missing soname and its apt package', () => {
     setPlatform('linux');
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(['libgtk-3.so.0', 'libnss3.so']));
     const result = linuxDeps(LIBS);
@@ -122,7 +122,7 @@ describe('diagnoseLinuxDependencies', () => {
     expect(result?.details).toContain('libcups2');
   });
 
-  it('skips instead of false-warning when ldconfig is unavailable (musl/minimal images)', () => {
+  it('should skip instead of false-warning when ldconfig is unavailable (musl/minimal images)', () => {
     setPlatform('linux');
     vi.mocked(execFileSync).mockImplementation(() => {
       throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
@@ -132,7 +132,7 @@ describe('diagnoseLinuxDependencies', () => {
     expect(result?.message).toMatch(/skipped/i);
   });
 
-  it('falls back to an absolute ldconfig path when it is not on PATH', () => {
+  it('should fall back to an absolute ldconfig path when it is not on PATH', () => {
     setPlatform('linux');
     // First candidate (`ldconfig`, bare) is not on the PATH; the /usr/sbin path resolves.
     vi.mocked(execFileSync).mockImplementation((bin) => {
@@ -144,7 +144,7 @@ describe('diagnoseLinuxDependencies', () => {
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 
-  it('does not count a library present only for a foreign architecture as found', () => {
+  it('should not count a library present only for a foreign architecture as found', () => {
     setPlatform('linux');
     setArch('x64');
     // Every soname is in the cache, but tagged for aarch64 only — an x64 binary
@@ -160,7 +160,7 @@ describe('diagnoseLinuxDependencies', () => {
     expect(result?.details).toContain('libcups.so.2');
   });
 
-  it('warns (not ok) when ldconfig is present but fails to run', () => {
+  it('should warn (not ok) when ldconfig is present but fails to run', () => {
     setPlatform('linux');
     // Non-ENOENT failure (e.g. a timeout) means ldconfig exists but could not
     // run — that must surface as a warning, not a silent passing check.

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { statSync } from 'node:fs';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { diagnoseBinary, diagnoseLinuxDependencies, type LinuxLibrary } from '../src/diagnostics.js';
 
 vi.mock('node:fs', async (importActual) => {
@@ -58,22 +58,15 @@ describe('diagnoseBinary', () => {
   });
 });
 
-// A representative subset — the check is list-agnostic, so the shape matters,
-// not the exact members.
 const LIBS: LinuxLibrary[] = [
   { soname: 'libgtk-3.so.0', aptPackage: 'libgtk-3-0' },
   { soname: 'libcups.so.2', aptPackage: 'libcups2' },
   { soname: 'libnss3.so', aptPackage: 'libnss3' },
 ];
 
-// The ldconfig ABI tag for the running arch, so mock entries survive the
-// arch filter on whatever host runs the tests (x64 or arm64; anything else is
-// unfiltered, so the tag is irrelevant there).
-const hostArchTag = (): string =>
-  (({ x64: 'x86-64', arm64: 'aarch64' }) as Record<string, string>)[process.arch] ?? 'x86-64';
-
-// Mimic `ldconfig -p` output.
-const ldconfigCache = (sonames: string[], archTag = hostArchTag()): string =>
+// Mimic `ldconfig -p` output. The tests pin the arch to x64, so entries are
+// tagged x86-64 to match (the foreign-arch test overrides the tag).
+const ldconfigCache = (sonames: string[], archTag = 'x86-64'): string =>
   [
     `${sonames.length} libs found in the cache \`/etc/ld.so.cache'`,
     ...sonames.map((s) => `\t${s} (libc6,${archTag}) => /usr/lib/${archTag}-linux-gnu/${s}`),
@@ -85,6 +78,11 @@ const linuxDeps = (libs: LinuxLibrary[]) =>
 describe('diagnoseLinuxDependencies', () => {
   const realPlatform = process.platform;
   const realArch = process.arch;
+
+  beforeEach(() => {
+    setPlatform('linux');
+    setArch('x64');
+  });
 
   afterEach(() => {
     setPlatform(realPlatform);
@@ -98,20 +96,17 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should report ok when every soname resolves in the ldconfig cache', () => {
-    setPlatform('linux');
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 
-  it('should not false-warn on the Debian/Ubuntu t64 package rename (issue #617)', () => {
-    setPlatform('linux');
+  it('should not false-warn on the Debian/Ubuntu t64 package rename', () => {
     // Package is libcups2t64, but the soname libcups.so.2 is unchanged, so it's still cached.
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 
   it('should warn and name the missing soname and its apt package', () => {
-    setPlatform('linux');
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(['libgtk-3.so.0', 'libnss3.so']));
     const result = linuxDeps(LIBS);
     expect(result?.status).toBe('warn');
@@ -121,7 +116,6 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should skip instead of false-warning when ldconfig is unavailable (musl/minimal images)', () => {
-    setPlatform('linux');
     vi.mocked(execFileSync).mockImplementation(() => {
       throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
     });
@@ -131,7 +125,6 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should fall back to an absolute ldconfig path when it is not on PATH', () => {
-    setPlatform('linux');
     vi.mocked(execFileSync).mockImplementation((bin) => {
       if (bin === 'ldconfig') {
         throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
@@ -142,8 +135,6 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should not count a library present only for a foreign architecture as found', () => {
-    setPlatform('linux');
-    setArch('x64');
     // In the cache but tagged aarch64 only — an x64 binary can't load them.
     vi.mocked(execFileSync).mockReturnValue(
       ldconfigCache(
@@ -157,7 +148,6 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should warn (not ok) when ldconfig is present but fails to run', () => {
-    setPlatform('linux');
     vi.mocked(execFileSync).mockImplementation(() => {
       throw Object.assign(new Error('spawnSync /usr/sbin/ldconfig ETIMEDOUT'), { code: 'ETIMEDOUT' });
     });

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -134,7 +134,7 @@ describe('diagnoseLinuxDependencies', () => {
   });
 
   it('should not count a library present only for a foreign architecture as found', () => {
-    // In the cache but tagged aarch64 only — an x64 binary can't load them.
+    // In the cache, but tagged aarch64 while the host is x64.
     vi.mocked(execFileSync).mockReturnValue(
       ldconfigCache(
         LIBS.map((l) => l.soname),

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -105,8 +105,7 @@ describe('diagnoseLinuxDependencies', () => {
 
   it('should not false-warn on the Debian/Ubuntu t64 package rename (issue #617)', () => {
     setPlatform('linux');
-    // Package is libcups2t64, but the soname libcups.so.2 is unchanged, so the
-    // cache still lists it — the check must pass with no warning.
+    // Package is libcups2t64, but the soname libcups.so.2 is unchanged, so it's still cached.
     vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
     expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
@@ -133,7 +132,6 @@ describe('diagnoseLinuxDependencies', () => {
 
   it('should fall back to an absolute ldconfig path when it is not on PATH', () => {
     setPlatform('linux');
-    // First candidate (`ldconfig`, bare) is not on the PATH; the /usr/sbin path resolves.
     vi.mocked(execFileSync).mockImplementation((bin) => {
       if (bin === 'ldconfig') {
         throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
@@ -146,8 +144,7 @@ describe('diagnoseLinuxDependencies', () => {
   it('should not count a library present only for a foreign architecture as found', () => {
     setPlatform('linux');
     setArch('x64');
-    // Every soname is in the cache, but tagged for aarch64 only — an x64 binary
-    // cannot load them, so they must be reported missing, not found.
+    // In the cache but tagged aarch64 only — an x64 binary can't load them.
     vi.mocked(execFileSync).mockReturnValue(
       ldconfigCache(
         LIBS.map((l) => l.soname),
@@ -161,8 +158,6 @@ describe('diagnoseLinuxDependencies', () => {
 
   it('should warn (not ok) when ldconfig is present but fails to run', () => {
     setPlatform('linux');
-    // Non-ENOENT failure (e.g. a timeout) means ldconfig exists but could not
-    // run — that must surface as a warning, not a silent passing check.
     vi.mocked(execFileSync).mockImplementation(() => {
       throw Object.assign(new Error('spawnSync /usr/sbin/ldconfig ETIMEDOUT'), { code: 'ETIMEDOUT' });
     });

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -1,10 +1,16 @@
+import { execFileSync } from 'node:child_process';
 import { statSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { diagnoseBinary } from '../src/diagnostics.js';
+import { diagnoseBinary, diagnoseLinuxDependencies, type LinuxLibrary } from '../src/diagnostics.js';
 
 vi.mock('node:fs', async (importActual) => {
   const actual = await importActual<typeof import('node:fs')>();
   return { ...actual, statSync: vi.fn() };
+});
+
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
 });
 
 vi.mock('../src/log.js', () => import('./__mock__/log.js'));
@@ -45,5 +51,84 @@ describe('diagnoseBinary', () => {
     setPlatform('darwin');
     stubMode(0o755);
     expect(binaryPermissions('/app/app')?.status).toBe('ok');
+  });
+});
+
+// A representative subset — the check is list-agnostic, so the shape matters,
+// not the exact members. libcups.so.2 is the #617 poster child (its package,
+// libcups2, becomes libcups2t64 on Debian Trixie / Ubuntu 24.04+).
+const LIBS: LinuxLibrary[] = [
+  { soname: 'libgtk-3.so.0', aptPackage: 'libgtk-3-0' },
+  { soname: 'libcups.so.2', aptPackage: 'libcups2' },
+  { soname: 'libnss3.so', aptPackage: 'libnss3' },
+];
+
+// Mimic `ldconfig -p`: a header line then one tab-indented entry per soname.
+const ldconfigCache = (sonames: string[]): string =>
+  [
+    `${sonames.length} libs found in the cache \`/etc/ld.so.cache'`,
+    ...sonames.map((s) => `\t${s} (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/${s}`),
+  ].join('\n');
+
+const linuxDeps = (libs: LinuxLibrary[]) =>
+  diagnoseLinuxDependencies(libs).find((r) => r.category === 'Linux Dependencies');
+
+describe('diagnoseLinuxDependencies', () => {
+  const realPlatform = process.platform;
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    vi.clearAllMocks();
+  });
+
+  it('returns nothing on non-Linux platforms', () => {
+    setPlatform('darwin');
+    expect(diagnoseLinuxDependencies(LIBS)).toEqual([]);
+  });
+
+  it('reports ok when every soname resolves in the ldconfig cache', () => {
+    setPlatform('linux');
+    vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
+    expect(linuxDeps(LIBS)?.status).toBe('ok');
+  });
+
+  it('does not false-warn on the Debian/Ubuntu t64 package rename (issue #617)', () => {
+    setPlatform('linux');
+    // Package is libcups2t64, but the soname libcups.so.2 is unchanged, so the
+    // cache still lists it — the check must pass with no warning.
+    vi.mocked(execFileSync).mockReturnValue(ldconfigCache(LIBS.map((l) => l.soname)));
+    expect(linuxDeps(LIBS)?.status).toBe('ok');
+  });
+
+  it('warns and names the missing soname and its apt package', () => {
+    setPlatform('linux');
+    vi.mocked(execFileSync).mockReturnValue(ldconfigCache(['libgtk-3.so.0', 'libnss3.so']));
+    const result = linuxDeps(LIBS);
+    expect(result?.status).toBe('warn');
+    expect(result?.message).toBe('1 library may be missing');
+    expect(result?.details).toContain('libcups.so.2');
+    expect(result?.details).toContain('libcups2');
+  });
+
+  it('skips instead of false-warning when ldconfig is unavailable (musl/minimal images)', () => {
+    setPlatform('linux');
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
+    });
+    const result = linuxDeps(LIBS);
+    expect(result?.status).toBe('ok');
+    expect(result?.message).toMatch(/skipped/i);
+  });
+
+  it('falls back to an absolute ldconfig path when it is not on PATH', () => {
+    setPlatform('linux');
+    // First candidate (`ldconfig`, bare) is not on the PATH; the /usr/sbin path resolves.
+    vi.mocked(execFileSync).mockImplementation((bin) => {
+      if (bin === 'ldconfig') {
+        throw Object.assign(new Error('spawn ldconfig ENOENT'), { code: 'ENOENT' });
+      }
+      return ldconfigCache(LIBS.map((l) => l.soname));
+    });
+    expect(linuxDeps(LIBS)?.status).toBe('ok');
   });
 });

--- a/packages/native-utils/test/diagnostics.spec.ts
+++ b/packages/native-utils/test/diagnostics.spec.ts
@@ -64,8 +64,7 @@ const LIBS: LinuxLibrary[] = [
   { soname: 'libnss3.so', aptPackage: 'libnss3' },
 ];
 
-// Mimic `ldconfig -p` output. The tests pin the arch to x64, so entries are
-// tagged x86-64 to match (the foreign-arch test overrides the tag).
+// Mimic `ldconfig -p` output.
 const ldconfigCache = (sonames: string[], archTag = 'x86-64'): string =>
   [
     `${sonames.length} libs found in the cache \`/etc/ld.so.cache'`,

--- a/packages/tauri-service/src/diagnostics.ts
+++ b/packages/tauri-service/src/diagnostics.ts
@@ -7,23 +7,24 @@ import {
   diagnoseLinuxDependencies,
   diagnosePlatform,
   isErr,
+  type LinuxLibrary,
 } from '@wdio/native-utils';
 import { ensureTauriDriver, ensureWebKitWebDriver } from './driverManager.js';
 import type { TauriServiceOptions } from './types.js';
 
 const log = createLogger('tauri-service');
 
-const TAURI_LINUX_PACKAGES = [
-  'libgtk-3-0',
-  'libgbm1',
-  'libasound2',
-  'libatk-bridge2.0-0',
-  'libcups2',
-  'libdrm2',
-  'libxkbcommon0',
-  'libxcomposite1',
-  'libxdamage1',
-  'libxrandr2',
+const TAURI_LINUX_LIBRARIES: LinuxLibrary[] = [
+  { soname: 'libgtk-3.so.0', aptPackage: 'libgtk-3-0' },
+  { soname: 'libgbm.so.1', aptPackage: 'libgbm1' },
+  { soname: 'libasound.so.2', aptPackage: 'libasound2' },
+  { soname: 'libatk-bridge-2.0.so.0', aptPackage: 'libatk-bridge2.0-0' },
+  { soname: 'libcups.so.2', aptPackage: 'libcups2' },
+  { soname: 'libdrm.so.2', aptPackage: 'libdrm2' },
+  { soname: 'libxkbcommon.so.0', aptPackage: 'libxkbcommon0' },
+  { soname: 'libXcomposite.so.1', aptPackage: 'libxcomposite1' },
+  { soname: 'libXdamage.so.1', aptPackage: 'libxdamage1' },
+  { soname: 'libXrandr.so.2', aptPackage: 'libxrandr2' },
 ];
 
 export async function diagnoseTauriEnvironment(
@@ -37,7 +38,7 @@ export async function diagnoseTauriEnvironment(
   results.push(...diagnosePlatform());
   results.push(...diagnoseDisplay());
   results.push(...diagnoseBinary(binaryPath));
-  results.push(...diagnoseLinuxDependencies(TAURI_LINUX_PACKAGES));
+  results.push(...diagnoseLinuxDependencies(TAURI_LINUX_LIBRARIES));
   results.push(...(await diagnoseDriver(options)));
   results.push(...(await diagnoseWebKit()));
   results.push(...diagnoseDiskSpace());


### PR DESCRIPTION
## Problem

`diagnoseLinuxDependencies` reported false **"packages may be missing"** warnings on **Debian Trixie / Ubuntu 24.04+**. The 64-bit `time_t` transition renamed packages (`libcups2` → `libcups2t64`) while the check still ran `dpkg -s libcups2`, which fails for the renamed package. Fixes #617.

The same code also reported **every** package missing on **non-dpkg distros** (Fedora / Arch / Void), because it shelled out to `dpkg` unconditionally and every call threw `ENOENT`.

## Fix — check sonames via `ldconfig`, not package names

The diagnostic now reads the `ldconfig -p` cache and checks runtime **sonames** instead of package names:

- The soname (`libcups.so.2`) is what the app actually `dlopen`s and is **unchanged by the t64 rename** — so the false positive disappears with nothing to special-case (no `t64` suffix logic, now or for the next transition).
- `ldconfig` ships with **glibc**, so the check no longer depends on any one package manager and behaves the same on dpkg / rpm / pacman / xbps systems.
- `ldconfig` is resolved via `ldconfig` → `/usr/sbin/ldconfig` → `/sbin/ldconfig` (it's off a non-root `PATH` on Debian/Fedora).
- When no `ldconfig` is available (musl/Alpine, minimal images), the check **skips** rather than emitting false warnings.

`electron-service` and `tauri-service` now declare their Linux deps as `{ soname, aptPackage }` pairs — the apt package name is kept only for the Debian/Ubuntu install hint in the warning.

## Why sonames (not "also check `${pkg}t64`")

Appending `t64` would patch Debian only and leave the non-dpkg false-positive. Checking sonames is *less* brittle than a package-name list (sonames are stable across distros and drift only on real ABI breaks), covers our entire stated distro matrix in one code path, and mirrors how Playwright validates native deps (detect via soname, map to package names only for the message).

## Tests

- **native-utils unit tests** (`diagnostics.spec.ts`): present → ok; the explicit **#617 t64 regression**; missing → warns and names the soname + apt package; `ldconfig` absent → skips (no false warn); absolute-path fallback; non-Linux → no-op.
- **Real-distro docker guard** (`tauri-app/docker/container-test.sh`): asserts that `libgtk-3.so.0` — always installed in a Tauri container — is never reported missing, across the existing docker matrix (`debian:12`, `ubuntu:24.04`, `fedora`, `arch`, `void`). The t64 renames from #617 are exercised by **`ubuntu:24.04` (Noble)**, which went through the same 64-bit `time_t` transition as the reported Debian Trixie — Debian itself is in the matrix only as pre-t64 Bookworm (`debian:12`), and Trixie is not present. `fedora`/`arch`/`void` cover the non-dpkg false-positive. This is a forward regression guard on the soname approach for exactly those distros (it wouldn't have matched the old dpkg output, which listed package names rather than sonames).

## Verification

- native-utils unit tests: 9 passed (6 new)
- electron-service diagnostics spec: 9 passed
- typecheck (native-utils / electron / tauri): clean
- `pnpm build` (electron + tauri + deps): 17/17
- Biome format + lint: clean

## Notes

- The warning text changes from "N packages may be missing" to "N libraries may be missing" (now lists sonames); no docs or snapshots referenced the old strings.
- Independent of #618; both touch `tauri-service/src/diagnostics.ts` but in different regions, so they merge cleanly whichever lands first.

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URC1fN1sFWsKjemfD8gDmS
