### PR TITLE
fix(flutter): unpin appium-flutter-driver, move to ^3.10.1

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -90,7 +90,7 @@
     "@wdio/native-types": "workspace:*",
     "@wdio/types": "catalog:default",
     "appium": "^3.6.0",
-    "appium-flutter-driver": "^3.9.1",
+    "appium-flutter-driver": "^3.10.1",
     "appium-uiautomator2-driver": "^8.2.2",
     "appium-xcuitest-driver": "^12.1.4",
     "cross-env": "^10.1.0",

--- a/fixtures/package-tests/flutter-app/package.json
+++ b/fixtures/package-tests/flutter-app/package.json
@@ -19,7 +19,7 @@
     "@wdio/native-types": "workspace:*",
     "@wdio/spec-reporter": "^9.30.1",
     "appium": "^3.6.0",
-    "appium-flutter-driver": "3.9.1",
+    "appium-flutter-driver": "^3.10.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/native-mobile-core/src/versionMatrix.ts
+++ b/packages/native-mobile-core/src/versionMatrix.ts
@@ -29,7 +29,7 @@ export const APPIUM_MATRIX: AppiumCompat[] = [
     drivers: {
       uiautomator2: { name: 'uiautomator2', source: 'appium-uiautomator2-driver', version: '^8.2.2' },
       xcuitest: { name: 'xcuitest', source: 'appium-xcuitest-driver', version: '^12.1.4' },
-      flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.9.1' },
+      flutter: { name: 'flutter', source: 'appium-flutter-driver', version: '^3.10.1' },
     },
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       appium-flutter-driver:
-        specifier: ^3.9.1
-        version: 3.9.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
+        specifier: ^3.10.1
+        version: 3.10.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       appium-uiautomator2-driver:
         specifier: ^8.2.2
         version: 8.2.2(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
@@ -750,8 +750,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       appium-flutter-driver:
-        specifier: 3.9.1
-        version: 3.9.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
+        specifier: ^3.10.1
+        version: 3.10.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3763,9 +3763,6 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  '@types/node@25.9.5':
-    resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
-
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
@@ -4046,10 +4043,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -4214,25 +4213,17 @@ packages:
     resolution: {integrity: sha512-HQxWiLRHOt9nMNRGot79hSNPqkrCqp+4qbjFEmQmunXlAzeM19f41hWKvW9bB27T/SaUC5UrT+80KnCLtbaw/w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
-  appium-flutter-driver@3.9.1:
-    resolution: {integrity: sha512-IKR+D3IYf5trMToVEgLPcgSEd/9ZJMw55WUAgw30tao/efl/cVXb4ZmvGlqjUHe99pzuxJN4/Wohui/FwSoHpA==}
+  appium-flutter-driver@3.10.1:
+    resolution: {integrity: sha512-FlUZkxhAgWJ6VaONd/ggLzelKO1PHWutZIV4pr+faC+Cdi0Pv4VLAFDkB9wTc5aufaETTXsAATCjwZVi2hcwSw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
     peerDependencies:
       appium: ^3.0.0
 
-  appium-flutter-finder@0.2.3:
-    resolution: {integrity: sha512-47Xp9FvuFONqygd6Ywjk8RJzH7QWmwrwvVU9Nhs6OCOY9v4pcFZsYsD/gUgDVdLF+Wops8K2pGSoTdoo7EJ6wg==}
-
-  appium-idb@2.0.10:
-    resolution: {integrity: sha512-k25bH3dWbir75iU51e4qMwN6UURcX/KY7zz7e8mZ5ESOVdwfeX4Tp7XxbvnIweHFPsbGPPBf7EmazBYC5a+/FQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
+  appium-flutter-finder@0.3.0:
+    resolution: {integrity: sha512-2eGO7gpV9WYXFb5DI+tuCGUFhNJixNi+54pKWRoDctOO1yS+NeuEtacCQmajeeyai2P4HJ3XyFQ4ZBJj/NEuHw==}
 
   appium-ios-device@3.1.21:
     resolution: {integrity: sha512-jufABr3k6fBGMzBlbzU4R2J8JfLvC5HYWscKEu0ntXz2YmYc+q8/iqXCpmp3rpqR/jGK5Ibqdrt0WkIpnQHQ3g==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
-
-  appium-ios-remotexpc@0.45.2:
-    resolution: {integrity: sha512-ff0cWRGHbamv6vXN3zuLYhWayebF6JIyc0fBctNes+81fFgnpt1bW7dFCRCbvCjh/iLvR5Kq13UZAmO/fYZ20Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
   appium-ios-remotexpc@5.13.2:
@@ -4245,10 +4236,6 @@ packages:
 
   appium-ios-simulator@9.1.2:
     resolution: {integrity: sha512-IVZKABOIvY8NZhYmNHVFc56MQhpoK1UXRSuzXrYW2jFu7jkb6n2szcfDefU4JS4rFOJOaA4LqOAQ9mcUUv+PSg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
-
-  appium-ios-tuntap@0.6.1:
-    resolution: {integrity: sha512-BeDS71T/a/AAZvmSA1oK9rgAGKKVeAKTM+Ft6vCPIJOR8LSPm7WCEQyjoyibUn0ZE//aV6gekbPo/dD3hsLTZg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
   appium-ios-tuntap@1.2.2:
@@ -4273,8 +4260,8 @@ packages:
     resolution: {integrity: sha512-P3q+/EHN2ir1XqCoR9u059Qn6Rp30w8qCdLRCzcIwb39GJo4DkV+4Gry+Za6BQtssto7jEbXq6KGc7LJDiCBvw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
-  appium-webdriveragent@11.4.3:
-    resolution: {integrity: sha512-yjNow/So/nVXbdhuFSRkV+bMXnmmqKc/v6AcEWbBEZ4RuAPYvoD+T4FnEL4eEVfLcJmP8QKeQ6xz8O57HFeIGw==}
+  appium-webdriveragent@15.1.6:
+    resolution: {integrity: sha512-CTiRQbI5t7I3+w2rqO0TizoV2UhRUwsfi9J+m4Dh4s2qGk+s+crFyyYylck4OhuFIXXGgr0DJvxBwiDs1XeGyQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
   appium-webdriveragent@16.1.3:
@@ -4289,8 +4276,8 @@ packages:
     resolution: {integrity: sha512-sgmzY4WjXvjYBK6CZM5UzZ169/qthUPk7LxTMuqu1JE75MbP8SazrWRWO/R7DQLQfnvHset9oQ6a+5IL6XrDrg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
 
-  appium-xcuitest-driver@10.43.1:
-    resolution: {integrity: sha512-MCUSesaNaa2rXP9xLbQmMFV9XmZH2LUK5TO/fD9kiSqQJzT31lxtN+U0elpUgfnu6ZIGkug+MB+x84RQud7Ahg==}
+  appium-xcuitest-driver@11.17.7:
+    resolution: {integrity: sha512-nQNGNscUTw64mqr8TJ0wSgEWaSTvw2FFK2LVeoxm9QP33FPGm2zcIvjJd1pcISmVQJpzkAcwn+XJbklAOo9EXw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10'}
     peerDependencies:
       appium: ^3.0.0-rc.2
@@ -5059,10 +5046,6 @@ packages:
 
   dmg-builder@26.15.3:
     resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
-
-  dnssd@0.4.1:
-    resolution: {integrity: sha512-mEz5Ii+o+k3kYHTXY6fTLOjCwraX8TQowIgUySAbEYuGqtSMbfBc/tvDZ8wGPywnmlLE6/XeXi6qPcAKVTvPUQ==}
-    hasBin: true
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -6732,12 +6715,6 @@ packages:
     resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
     engines: {node: '>=18.0.0'}
 
-  moment-timezone@0.6.3:
-    resolution: {integrity: sha512-pVEPA/HCFHHbwJ130ywnzYuZpkEGcP6Daa/OwNebpA18MybeFHmQilAGGovXgWijQ8vQtmud9jZrziUBgsykfg==}
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
   morgan@1.11.0:
     resolution: {integrity: sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==}
     engines: {node: '>= 0.8.0'}
@@ -8190,9 +8167,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -8728,43 +8702,6 @@ snapshots:
   '@appium/strongbox@1.1.3':
     dependencies:
       env-paths: 4.0.0
-
-  '@appium/support@7.2.6(@types/node@25.9.5)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@appium/logger': 2.0.10
-      '@appium/types': 1.6.0(@appium/logger@2.0.10)
-      archiver: 8.0.0
-      asyncbox: 6.3.5
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      bluebird: 3.7.2
-      bplist-creator: 0.1.1
-      bplist-parser: 0.3.2
-      form-data: 4.0.6
-      glob: 13.0.6
-      jsftp: 2.1.3(supports-color@8.1.1)
-      klaw: 4.1.0
-      lockfile: 1.0.4
-      normalize-package-data: 8.0.0
-      plist: 4.0.0
-      pluralize: 8.0.0
-      sanitize-filename: 1.6.4
-      semver: 7.8.5
-      shell-quote: 1.10.0
-      teen_process: 4.1.9
-      type-fest: 5.8.0
-      uuid: 14.0.1
-      which: 6.0.1
-      yauzl: 3.4.0
-    optionalDependencies:
-      sharp: 0.35.3(@types/node@25.9.5)
-    transitivePeerDependencies:
-      - '@types/node'
-      - bare-abort-controller
-      - bare-buffer
-      - debug
-      - react-native-b4a
-      - supports-color
-    optional: true
 
   '@appium/support@7.2.6(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
@@ -10927,11 +10864,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/node@25.9.5':
-    dependencies:
-      undici-types: 7.24.6
-    optional: true
-
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
@@ -11695,14 +11627,14 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  appium-flutter-driver@3.9.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6):
+  appium-flutter-driver@3.10.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6):
     dependencies:
       appium: 3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       appium-android-driver: 13.4.0(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
-      appium-flutter-finder: 0.2.3
+      appium-flutter-finder: 0.3.0
       appium-ios-device: 3.1.21(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-uiautomator2-driver: 8.2.2(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
-      appium-xcuitest-driver: 10.43.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
+      appium-xcuitest-driver: 11.17.7(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
       asyncbox: 6.4.2
       bluebird: 3.7.2
       lodash: 4.18.1
@@ -11719,22 +11651,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  appium-flutter-finder@0.2.3: {}
-
-  appium-idb@2.0.10(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@appium/support': 7.2.6(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      asyncbox: 6.4.2
-      bluebird: 3.7.2
-      lodash: 4.18.1
-      teen_process: 4.2.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - bare-abort-controller
-      - bare-buffer
-      - debug
-      - react-native-b4a
-      - supports-color
+  appium-flutter-finder@0.3.0: {}
 
   appium-ios-device@3.1.21(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -11751,28 +11668,6 @@ snapshots:
       - debug
       - react-native-b4a
       - supports-color
-
-  appium-ios-remotexpc@0.45.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@appium/strongbox': 1.1.3
-      '@appium/support': 7.2.6(@types/node@25.9.5)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@types/node': 25.9.5
-      '@xmldom/xmldom': 0.9.10
-      appium-ios-tuntap: 0.6.1(@types/node@25.9.5)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      commander: 14.0.3
-      dnssd: 0.4.1
-      minimatch: 10.2.6
-      node-devicectl: 1.4.3
-      npm-run-all2: 8.0.4
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - debug
-      - react-native-b4a
-      - supports-color
-    optional: true
 
   appium-ios-remotexpc@5.13.2(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -11831,21 +11726,6 @@ snapshots:
       - debug
       - react-native-b4a
       - supports-color
-
-  appium-ios-tuntap@0.6.1(@types/node@25.9.5)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@appium/support': 7.2.6(@types/node@25.9.5)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      node-addon-api: 8.9.1
-      node-gyp-build: 4.8.4
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bare-abort-controller
-      - bare-buffer
-      - debug
-      - react-native-b4a
-      - supports-color
-    optional: true
 
   appium-ios-tuntap@1.2.2(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
@@ -11927,18 +11807,15 @@ snapshots:
 
   appium-uiautomator2-server@10.3.5: {}
 
-  appium-webdriveragent@11.4.3(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  appium-webdriveragent@15.1.6(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@appium/base-driver': 10.7.2(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@appium/strongbox': 1.1.3
       '@appium/support': 7.2.6(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      appium-ios-device: 3.1.21(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-ios-simulator: 8.2.8(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       async-lock: 1.4.1
       asyncbox: 6.4.2
       axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      bluebird: 3.7.2
-      lodash: 4.18.1
       teen_process: 4.2.1
     transitivePeerDependencies:
       - '@appium/logger'
@@ -11996,28 +11873,24 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  appium-xcuitest-driver@10.43.1(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6):
+  appium-xcuitest-driver@11.17.7(@appium/logger@2.0.10)(@types/node@26.1.2)(appium@3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6):
     dependencies:
+      '@appium/css-locator-to-native': 1.0.6
       '@appium/strongbox': 1.1.3
       '@colors/colors': 1.6.0
       appium: 3.6.0(@types/node@26.1.2)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(utf-8-validate@6.0.6)
-      appium-idb: 2.0.10(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-ios-device: 3.1.21(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-ios-simulator: 8.2.8(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-remote-debugger: 15.10.9(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      appium-webdriveragent: 11.4.3(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      appium-webdriveragent: 15.1.6(@appium/logger@2.0.10)(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       appium-xcode: 6.2.6(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       async-lock: 1.4.1
       asyncbox: 6.4.2
       axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      bluebird: 3.7.2
       commander: 14.0.3
-      css-selector-parser: 3.3.0
+      dayjs: 1.11.21
       js2xmlparser2: 0.2.0
-      lodash: 4.18.1
       lru-cache: 11.5.2
-      moment: 2.30.1
-      moment-timezone: 0.6.3
       node-devicectl: 1.4.3
       node-simctl: 8.2.9
       portscanner: 2.2.0
@@ -12026,7 +11899,7 @@ snapshots:
       winston: 3.19.0
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
-      appium-ios-remotexpc: 0.45.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      appium-ios-remotexpc: 5.13.2(@types/node@26.1.2)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@appium/logger'
       - '@types/node'
@@ -12901,9 +12774,6 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
-
-  dnssd@0.4.1:
-    optional: true
 
   dom-serializer@2.0.0:
     dependencies:
@@ -14815,12 +14685,6 @@ snapshots:
 
   modern-tar@0.7.7: {}
 
-  moment-timezone@0.6.3:
-    dependencies:
-      moment: 2.30.1
-
-  moment@2.30.1: {}
-
   morgan@1.11.0(supports-color@8.1.1):
     dependencies:
       basic-auth: 2.0.1
@@ -15784,40 +15648,6 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.3(@types/node@25.9.5):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.9.5
-    optional: true
-
   sharp@0.35.3(@types/node@26.1.2):
     dependencies:
       '@img/colour': 1.1.0
@@ -16373,9 +16203,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
-
-  undici-types@7.24.6:
-    optional: true
 
   undici-types@8.3.0: {}
 


### PR DESCRIPTION
## Summary
- `appium-flutter-driver@3.10.1` works around the broken `appium-flutter-finder@0.3.0` `exports` field (appium/appium-flutter-driver#923) by dynamically `import()`-ing the finder instead of `require()`-ing it, so the CJS-consumer resolution failure this repo hit no longer applies.
- Moves the package-test fixture (`fixtures/package-tests/flutter-app/package.json`), the Appium version matrix (`packages/native-mobile-core/src/versionMatrix.ts`), and `e2e/package.json` off the `3.9.1` stopgap pin from #603, onto `^3.10.1` — a caret range that tracks future `3.10.x` patches without floating to the ESM-only `4.0.0` major.
- `appium-flutter-finder` itself is unchanged (still `0.3.0`, still missing a `require`/`default` export condition) — the fix lives entirely in how `appium-flutter-driver` loads it, so no finder-side change is needed.

## Verification
- `pnpm test:package:flutter` (the isolated fresh-install repro from the issue): the sandbox install now resolves `appium-flutter-driver@3.10.1`, and `wdio run` loads it cleanly — no `ERR_PACKAGE_PATH_NOT_EXPORTED` / "No exports main defined" error. It fails later only on `FLUTTER_APP_PATH is not set`, expected here since there's no built Flutter app/device in this environment.
- `pnpm --filter @wdio/native-mobile-core test` — 112/112 passing, including the version-matrix drift guard (major stays `3`, so the guard flows through untouched) and `appiumDriverManager.spec.ts` (which derives its expected install spec from the matrix, not a hardcoded version).
- `pnpm --filter @wdio/flutter-service test` — 108/108 passing.
- `pnpm-lock.yaml` regenerated and re-verified with `--frozen-lockfile`.

## Test plan
- [x] Unit tests pass (`@wdio/native-mobile-core`, `@wdio/flutter-service`)
- [x] Isolated package-test install (`pnpm test:package:flutter`) no longer hits the exports error
- [x] Lockfile regenerated and frozen-lockfile clean
- [ ] CI Flutter E2E (Android/iOS) — for reviewer/CI confirmation with real devices

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKmcJy8r9Hgt441gk7Cyxt