### PR TITLE
chore(package-tests): bump docker distro images (Debian 12→13, Fedora 40→44)

### DIFF
--- a/fixtures/package-tests/dioxus-app/docker/debian.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/debian.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CI=true

--- a/fixtures/package-tests/dioxus-app/docker/fedora.dockerfile
+++ b/fixtures/package-tests/dioxus-app/docker/fedora.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:44
 
 ENV CI=true
 

--- a/fixtures/package-tests/tauri-app/docker/README.md
+++ b/fixtures/package-tests/tauri-app/docker/README.md
@@ -214,12 +214,12 @@ cat /tmp/docker-test-ubuntu.log
 - **Pros:** Most documented, stable, wide tooling support, GitHub Actions default
 - **Cons:** Some packages may lag behind latest
 
-### Debian 12 (Bookworm)
+### Debian 13 (Trixie)
 - **Use case:** Production builds, long-term stability
 - **Pros:** Rock-solid, conservative updates, excellent for production
 - **Cons:** Slightly older packages than Ubuntu
 
-### Fedora 40+
+### Fedora 44
 - **Use case:** Development, RHEL-based workflows
 - **Pros:** Latest stable packages, upstream for RHEL, modern environment
 - **Cons:** More frequent updates, shorter support lifecycle

--- a/fixtures/package-tests/tauri-app/docker/debian.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/debian.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:13
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CI=true

--- a/fixtures/package-tests/tauri-app/docker/fedora.dockerfile
+++ b/fixtures/package-tests/tauri-app/docker/fedora.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:44
 
 ENV CI=true
 


### PR DESCRIPTION
## What

Bumps the stale pinned base images in the Tauri and Dioxus per-distro docker package-test matrices:

| image | before | after | why |
|---|---|---|---|
| Fedora | `fedora:40` | `fedora:44` | **40 is EOL** (Fedora supports N/N-1; 40 went EOL mid-2025). EOL releases get their repos moved to the archive mirror, which eventually breaks the dockerfile's `dnf install`. 44 is supported until ~mid-2027. |
| Debian | `debian:12` | `debian:13` | 12 (Bookworm) is oldstable; regular support ended 2026-07. 13 (Trixie) is current stable — and the distro **#617** was reported on (the 64-bit `time_t` / t64 rename), so this exercises that exact environment. |

Left unchanged: `ubuntu:24.04` (current LTS, covers post-t64), and the rolling `archlinux:latest` / `voidlinux:latest`.

## Scope

- 4 dockerfiles (`{tauri,dioxus}-app/docker/{debian,fedora}.dockerfile`) + the Tauri docker `README.md` distro headers.
- Package names in the dockerfiles are generic (`webkit2gtk4.1-devel`, `libwebkit2gtk-4.1-dev`, `webkitgtk6.0`, NodeSource `setup_24.x`, rustup) and carry across these releases.
- I can't run the Linux container matrix locally (macOS) — **CI validates the actual builds**. If a package was renamed on the newer release, it'll surface there.
- Left the `Debian 12+` / `Fedora 40+` **minimum-version support** claims in the docs as-is (they describe service compatibility, not the test image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URC1fN1sFWsKjemfD8gDmS