### PR TITLE
test(react-native): exercise iOS boot-cap defaults on the RN-iOS leg (#428)

### DIFF
--- a/e2e/wdio.react-native.conf.ts
+++ b/e2e/wdio.react-native.conf.ts
@@ -121,24 +121,9 @@ const capabilities: ReactNativeCapabilities[] = [
           // as "failed to finish booting" even though our `bootstatus -b` step passed (#359). CI
           // exports RN_IOS_UDID from the boot step; omitted locally (appium resolves by name).
           ...(process.env.RN_IOS_UDID ? { 'appium:udid': process.env.RN_IOS_UDID } : {}),
-          // wdaLaunchTimeout is a ceiling, not a delay. CI pre-builds WDA into RN_WDA_DD (reused
-          // via usePreinstalledWDA below — simctl install/launch) so the first session just launches
-          // it — fast, a tight ceiling is fine. Without a prebuilt WDA (local) appium compiles it on
-          // the first session (several minutes), so the wait must stay generous. connectionRetryTimeout
-          // below tracks this.
-          // Prebuilt WDA just launches (no compile), so a tight per-attempt ceiling lets several
-          // startup retries fit inside connectionRetryTimeout below.
-          'appium:wdaLaunchTimeout': process.env.RN_WDA_DD ? 120000 : 720000,
-          // CI boots the sim headless (simctl). Without isHeadless, XCUITest restarts it on
-          // session-create "with the Simulator window visible" — a ~225s GUI re-boot on a
-          // display-less runner that raced the 240s ceiling below and was the proven root cause
-          // of the #359 first-session flake (the appium debug log showed "booted in 230.541s").
-          // Headless skips that restart and reuses the already-booted sim. CI-only: a local run
-          // still wants the visible window, and appium boots its own sim there.
-          ...(process.env.CI ? { 'appium:isHeadless': true } : {}),
-          // Safety margin for appium's boot monitor on a cold/slow runner; with isHeadless above
-          // the redundant restart is gone, so this ceiling should no longer be approached in CI.
-          'appium:simulatorStartupTimeout': 240000,
+          // wdaLaunchTimeout + simulatorStartupTimeout + isHeadless are intentionally omitted
+          // so native-mobile-core's applyBootCapDefaults actually fills them in.
+          // https://github.com/webdriverio/desktop-mobile/issues/428
           // WDA on GitHub-Actions sims often fails to come up on the first attempt (ECONNREFUSED
           // 8100 / session-create timeout); appium's default is only 2 startup retries — bump it.
           'appium:wdaStartupRetries': 5,

--- a/packages/native-mobile-core/src/deviceManager.ts
+++ b/packages/native-mobile-core/src/deviceManager.ts
@@ -110,10 +110,13 @@ export function applyBootCapDefaults(capability: Record<string, unknown>, platfo
   }
 
   // iOS: generous ceilings for a cold WDA build / slow sim boot; tighten by pinning a
-  // prebuilt WDA (derivedDataPath + usePrebuiltWDA) yourself. isHeadless only in CI —
-  // a local run wants the visible Simulator window.
+  // prebuilt WDA (derivedDataPath + usePrebuiltWDA) yourself.
   setIfUnset('appium:wdaLaunchTimeout', 720000);
   setIfUnset('appium:simulatorStartupTimeout', 240000);
+  // CI boots the sim headless (simctl); without isHeadless, XCUITest restarts it with the
+  // window visible — a slow re-boot that raced simulatorStartupTimeout. A local run wants
+  // the visible window.
+  // https://github.com/webdriverio/desktop-mobile/issues/359
   if (process.env.CI) {
     setIfUnset('appium:isHeadless', true);
   }


### PR DESCRIPTION
## What

Follow-up to #606, which trialled this on the **Flutter-iOS** leg first per #428's own risk note (`applyBootCapDefaults`' flat `wdaLaunchTimeout: 720000` is more generous than the env-conditional value the e2e pinned by hand, and could mask a slow first session). That trial went green in CI, so this extends the same treatment to **RN-iOS**: drops the explicit `appium:wdaLaunchTimeout` / `appium:simulatorStartupTimeout` / `appium:isHeadless` caps from the RN-iOS e2e capability and relies on `native-mobile-core`'s `applyBootCapDefaults` (apply-if-unset, invoked by `MobileBaseLauncher`) instead.

With this + #606 merged, both legs named in #428 are covered.

## Kept (as the issue calls out)

- **`appium:udid`** — the exact pre-booted sim pin (dropping it reintroduces the #359 "booted a different sim" flake).
- **`appium:wdaStartupRetries` / `wdaStartupRetryInterval`** and the **prebuilt-WDA reuse** (`usePreinstalledWDA` + `prebuiltWDAPath`) — `applyBootCapDefaults` only sets timeouts/headless, so these must stay explicit.

## Also moved

The `isHeadless` rationale — the proven #359 first-session flake where XCUITest restarts the sim with the window visible, racing `simulatorStartupTimeout` — into `applyBootCapDefaults` itself. The e2e config no longer sets the value, so it's no longer the right place to explain why it matters; the defaulting function is now the one place that knowledge needs to live for a future editor.

## Verification

- `@wdio/native-mobile-core` unit tests: 112/112 (incl. `applyBootCapDefaults` coverage).
- `@wdio/react-native-service` typecheck + tests: 144/144.
- Full pre-push task set (36 tasks across affected packages): all green.
- The real signal is this PR's **RN [iOS]** e2e leg going green with the defaults applied, same as #606.

Refs #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKmcJy8r9Hgt441gk7Cyxt