### PR TITLE
feat(electron): resolve the Chromium version from the app binary when the map can't (#578)

### DIFF
--- a/fixtures/package-tests/electron-builder-app-esm/package.json
+++ b/fixtures/package-tests/electron-builder-app-esm/package.json
@@ -11,7 +11,7 @@
     "build": "electron-vite build && electron-builder",
     "preview": "electron-vite preview",
     "start": "electron .",
-    "test": "cross-env DEBUG=wdio-electron-service wdio run wdio.conf.ts",
+    "test": "cross-env DEBUG=wdio-electron-service wdio run wdio.conf.ts && cross-env DEBUG=wdio-electron-service wdio run wdio.probe.conf.ts",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {

--- a/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
@@ -1,10 +1,8 @@
 import process from 'node:process';
 import { browser } from '@wdio/electron-service';
 
-// This capability set a fork `browserVersion` the Electron→Chromium map cannot resolve, so this
-// session only booted because onPrepare probed the packaged binary for its Chromium version (#578).
-// Had the probe failed, onPrepare would have thrown before any session started — so a live session
-// is itself the proof; the assertion below confirms the resolved version is the binary's real one.
+// A booted session is itself proof the probe worked (onPrepare throws otherwise, see
+// wdio.probe.conf.ts); the assertion confirms the resolved version is the binary's real one.
 describe('Chromium-version binary probe (#578)', () => {
   it('should boot with the Chromium version probed from the packaged binary', async () => {
     const chromeFromBinary = await browser.electron.execute(() => process.versions.chrome);

--- a/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
@@ -1,8 +1,9 @@
 import process from 'node:process';
 import { browser } from '@wdio/electron-service';
 
-// A booted session is itself proof the probe worked (onPrepare throws otherwise, see
-// wdio.probe.conf.ts); the assertion confirms the resolved version is the binary's real one.
+// A booted session is itself proof the probe worked: a failed probe leaves the fork browserVersion
+// ('1000.0.0-probe', see wdio.probe.conf.ts), which has no Chromedriver to download, so the session
+// never starts. The assertion confirms the resolved version is the binary's real one.
 describe('Chromium-version binary probe', () => {
   it('should boot with the Chromium version probed from the packaged binary', async () => {
     const chromeFromBinary = await browser.electron.execute(() => process.versions.chrome);

--- a/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
@@ -3,7 +3,7 @@ import { browser } from '@wdio/electron-service';
 
 // A booted session is itself proof the probe worked (onPrepare throws otherwise, see
 // wdio.probe.conf.ts); the assertion confirms the resolved version is the binary's real one.
-describe('Chromium-version binary probe (#578)', () => {
+describe('Chromium-version binary probe', () => {
   it('should boot with the Chromium version probed from the packaged binary', async () => {
     const chromeFromBinary = await browser.electron.execute(() => process.versions.chrome);
 

--- a/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/test/probe.spec.ts
@@ -1,0 +1,15 @@
+import process from 'node:process';
+import { browser } from '@wdio/electron-service';
+
+// This capability set a fork `browserVersion` the Electron→Chromium map cannot resolve, so this
+// session only booted because onPrepare probed the packaged binary for its Chromium version (#578).
+// Had the probe failed, onPrepare would have thrown before any session started — so a live session
+// is itself the proof; the assertion below confirms the resolved version is the binary's real one.
+describe('Chromium-version binary probe (#578)', () => {
+  it('should boot with the Chromium version probed from the packaged binary', async () => {
+    const chromeFromBinary = await browser.electron.execute(() => process.versions.chrome);
+
+    expect(chromeFromBinary).toMatch(/^\d+\.\d+\.\d+/);
+    expect(browser.capabilities.browserVersion).toBe(chromeFromBinary);
+  });
+});

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.conf.ts
@@ -6,7 +6,7 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname);
 export const config: Options.Testrunner = {
   runner: 'local',
   specs: ['./test/**/*.spec.ts'],
-  // The probe scenario runs under wdio.probe.conf.ts (a fork browserVersion + explicit binary).
+  // The probe scenario has its own config, wdio.probe.conf.ts.
   exclude: ['./test/probe.spec.ts'],
   maxInstances: 1,
   capabilities: [

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
@@ -4,9 +4,10 @@ import type { Options } from '@wdio/types';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-// Force onPrepare's last-resort binary probe (#578): a fork `browserVersion` the map can't resolve,
-// plus an explicit binary path (a fork version would break auto-detection). The session boots only
-// if the probe reads Chromium off the packaged binary.
+// Force onPrepare's last-resort binary probe: a fork `browserVersion` the map can't resolve, plus an
+// explicit binary path (a fork version would break auto-detection). The session boots only if the
+// probe reads Chromium off the packaged binary.
+// See https://github.com/webdriverio/desktop-mobile/issues/578
 const appBinaryPath = await getElectronBinaryPath(__dirname);
 
 export const config: Options.Testrunner = {

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
@@ -1,8 +1,9 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getElectronBinaryPath } from '@wdio/electron-service';
 import type { Options } from '@wdio/types';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Force onPrepare's last-resort binary probe: a fork `browserVersion` the map can't resolve, plus an
 // explicit binary path (a fork version would break auto-detection).

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
@@ -4,11 +4,9 @@ import type { Options } from '@wdio/types';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-// Resolve the real packaged binary up front (using the actually-installed Electron version), then
-// hand it to the service explicitly. Paired with a fork `browserVersion` that the Electron→Chromium
-// map cannot resolve, this forces onPrepare's last-resort binary probe (#578): the session only
-// boots if the probe reads the Chromium version off the packaged binary — otherwise onPrepare
-// throws before any session starts.
+// Force onPrepare's last-resort binary probe (#578): a fork `browserVersion` the map can't resolve,
+// plus an explicit binary path (a fork version would break auto-detection). The session boots only
+// if the probe reads Chromium off the packaged binary.
 const appBinaryPath = await getElectronBinaryPath(__dirname);
 
 export const config: Options.Testrunner = {

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
@@ -5,8 +5,7 @@ import type { Options } from '@wdio/types';
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 // Force onPrepare's last-resort binary probe: a fork `browserVersion` the map can't resolve, plus an
-// explicit binary path (a fork version would break auto-detection). The session boots only if the
-// probe reads Chromium off the packaged binary.
+// explicit binary path (a fork version would break auto-detection).
 // See https://github.com/webdriverio/desktop-mobile/issues/578
 const appBinaryPath = await getElectronBinaryPath(__dirname);
 

--- a/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
+++ b/fixtures/package-tests/electron-builder-app-esm/wdio.probe.conf.ts
@@ -1,17 +1,25 @@
 import path from 'node:path';
+import { getElectronBinaryPath } from '@wdio/electron-service';
 import type { Options } from '@wdio/types';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
+// Resolve the real packaged binary up front (using the actually-installed Electron version), then
+// hand it to the service explicitly. Paired with a fork `browserVersion` that the Electron→Chromium
+// map cannot resolve, this forces onPrepare's last-resort binary probe (#578): the session only
+// boots if the probe reads the Chromium version off the packaged binary — otherwise onPrepare
+// throws before any session starts.
+const appBinaryPath = await getElectronBinaryPath(__dirname);
+
 export const config: Options.Testrunner = {
   runner: 'local',
-  specs: ['./test/**/*.spec.ts'],
-  // The probe scenario runs under wdio.probe.conf.ts (a fork browserVersion + explicit binary).
-  exclude: ['./test/probe.spec.ts'],
+  specs: ['./test/probe.spec.ts'],
+  exclude: [],
   maxInstances: 1,
   capabilities: [
     {
       browserName: 'electron',
+      browserVersion: '1000.0.0-probe',
     },
   ],
   logLevel: 'trace',
@@ -27,7 +35,7 @@ export const config: Options.Testrunner = {
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
   autoXvfb: true,
-  services: ['electron'],
+  services: [['electron', { appBinaryPath }]],
   framework: 'mocha',
   reporters: ['spec'],
   mochaOpts: {

--- a/packages/electron-service/src/binaryProbe.ts
+++ b/packages/electron-service/src/binaryProbe.ts
@@ -22,7 +22,9 @@ const CHROMIUM_VERSION_PATTERN = /^\d+\.\d+\.\d+/;
 export function probeChromiumVersion(binaryPath: string): Promise<string | undefined> {
   let pending = probeCache.get(binaryPath);
   if (!pending) {
-    pending = runProbe(binaryPath);
+    // Guard the "resolves undefined on failure" contract: a stray rejection must not surface as an
+    // unhandled rejection, a cached rejected promise, or a fatal onPrepare error.
+    pending = runProbe(binaryPath).catch(() => undefined);
     probeCache.set(binaryPath, pending);
     // Cache a success (a binary's Chromium version is stable) but not a failure — a transient
     // spawn/timeout/fuse-read failure must not poison later retries for the same binary.
@@ -61,12 +63,21 @@ async function runProbe(binaryPath: string): Promise<string | undefined> {
           log.debug(`Chromium version probe failed for ${binaryPath}: ${error.message}`);
           return resolve(undefined);
         }
-        const version = stdout.trim();
-        if (CHROMIUM_VERSION_PATTERN.test(version)) {
+        // Take the last version-shaped line: an inherited NODE_OPTIONS preload can print to stdout
+        // before the `-p` result, so the version isn't guaranteed to lead (or be all of) stdout.
+        const version = stdout
+          .trim()
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .reverse()
+          .find((line) => CHROMIUM_VERSION_PATTERN.test(line));
+        if (version) {
           log.debug(`Probed Chromium v${version} from ${binaryPath}`);
           return resolve(version);
         }
-        log.debug(`Chromium version probe returned unexpected output for ${binaryPath}: ${JSON.stringify(version)}`);
+        log.debug(
+          `Chromium version probe returned unexpected output for ${binaryPath}: ${JSON.stringify(stdout.trim())}`,
+        );
         resolve(undefined);
       },
     );

--- a/packages/electron-service/src/binaryProbe.ts
+++ b/packages/electron-service/src/binaryProbe.ts
@@ -1,0 +1,69 @@
+import { execFile } from 'node:child_process';
+import { createLogger } from '@wdio/native-utils';
+import { checkRunAsNodeFuse } from './fuses.js';
+
+const log = createLogger('electron-service', 'probe');
+
+// `onPrepare` maps over every capability concurrently and capabilities commonly
+// share a binary, so cache the in-flight promise per binary path to dedupe probes.
+const probeCache = new Map<string, Promise<string | undefined>>();
+
+const PROBE_TIMEOUT_MS = 10_000;
+const CHROMIUM_VERSION_PATTERN = /^\d+\.\d+\.\d+/;
+
+/**
+ * Resolve an Electron build's Chromium version by running the binary as a Node
+ * CLI (`ELECTRON_RUN_AS_NODE=1 <binary> -p process.versions.chrome`). Used as a
+ * last resort when the Electron→Chromium map has no entry — nightly and forked
+ * builds, or a release newer than the bundled map when the online lookup is
+ * unavailable. `-p` does not load the app's main script, so no app code runs.
+ *
+ * Returns `undefined` on any failure (RunAsNode fuse disabled, spawn error,
+ * timeout, unparseable output) so the caller falls through to its existing error.
+ */
+export function probeChromiumVersion(binaryPath: string): Promise<string | undefined> {
+  let pending = probeCache.get(binaryPath);
+  if (!pending) {
+    pending = runProbe(binaryPath);
+    probeCache.set(binaryPath, pending);
+  }
+  return pending;
+}
+
+/** Test-only: clear the per-binary probe cache. */
+export function resetProbeCache(): void {
+  probeCache.clear();
+}
+
+async function runProbe(binaryPath: string): Promise<string | undefined> {
+  const fuse = await checkRunAsNodeFuse(binaryPath);
+  if (!fuse.canRunAsNode) {
+    return undefined;
+  }
+
+  return new Promise((resolve) => {
+    execFile(
+      binaryPath,
+      ['-p', 'process.versions.chrome'],
+      {
+        encoding: 'utf8',
+        timeout: PROBE_TIMEOUT_MS,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          log.debug(`Chromium version probe failed for ${binaryPath}: ${error.message}`);
+          return resolve(undefined);
+        }
+        const version = stdout.trim();
+        if (CHROMIUM_VERSION_PATTERN.test(version)) {
+          log.debug(`Probed Chromium v${version} from ${binaryPath}`);
+          return resolve(version);
+        }
+        log.debug(`Chromium version probe returned unexpected output for ${binaryPath}: ${JSON.stringify(version)}`);
+        resolve(undefined);
+      },
+    );
+  });
+}

--- a/packages/electron-service/src/binaryProbe.ts
+++ b/packages/electron-service/src/binaryProbe.ts
@@ -4,8 +4,7 @@ import { checkRunAsNodeFuse } from './fuses.js';
 
 const log = createLogger('electron-service', 'probe');
 
-// `onPrepare` maps over every capability concurrently and capabilities commonly
-// share a binary, so cache the in-flight promise per binary path to dedupe probes.
+// Dedupe probes of a shared binary: onPrepare probes every capability concurrently.
 const probeCache = new Map<string, Promise<string | undefined>>();
 
 const PROBE_TIMEOUT_MS = 10_000;
@@ -18,8 +17,7 @@ const CHROMIUM_VERSION_PATTERN = /^\d+\.\d+\.\d+/;
  * builds, or a release newer than the bundled map when the online lookup is
  * unavailable. `-p` does not load the app's main script, so no app code runs.
  *
- * Returns `undefined` on any failure (RunAsNode fuse disabled, spawn error,
- * timeout, unparseable output) so the caller falls through to its existing error.
+ * Returns `undefined` on any failure, so the caller falls through to its existing error.
  */
 export function probeChromiumVersion(binaryPath: string): Promise<string | undefined> {
   let pending = probeCache.get(binaryPath);

--- a/packages/electron-service/src/binaryProbe.ts
+++ b/packages/electron-service/src/binaryProbe.ts
@@ -26,6 +26,13 @@ export function probeChromiumVersion(binaryPath: string): Promise<string | undef
   if (!pending) {
     pending = runProbe(binaryPath);
     probeCache.set(binaryPath, pending);
+    // Cache a success (a binary's Chromium version is stable) but not a failure — a transient
+    // spawn/timeout/fuse-read failure must not poison later retries for the same binary.
+    void pending.then((version) => {
+      if (version === undefined && probeCache.get(binaryPath) === pending) {
+        probeCache.delete(binaryPath);
+      }
+    });
   }
   return pending;
 }

--- a/packages/electron-service/src/fuses.ts
+++ b/packages/electron-service/src/fuses.ts
@@ -73,18 +73,14 @@ export interface RunAsNodeCheckResult {
 }
 
 /**
- * Checks whether the Electron binary may be run as a plain Node process (the
- * `RunAsNode` fuse). The Chromium-version probe sets `ELECTRON_RUN_AS_NODE=1`
- * and runs the binary with `-p`; if this fuse is disabled that env var is
- * ignored and the binary would launch the real GUI, so the probe must not run.
+ * Whether the Electron binary may run as a plain Node process (the `RunAsNode`
+ * fuse). The Chromium probe runs `ELECTRON_RUN_AS_NODE=1 <binary> -p …`; if this
+ * fuse is disabled the env var is ignored and the binary launches its real GUI,
+ * so the probe must be skipped.
  *
- * Failing open on an unreadable fuse is safe: a disabled `RunAsNode` fuse is
- * always readable (that is how it gets flipped) and is caught below, so a read
- * failure means either no fuses at all (the env var is honoured) or an
+ * Fail-open is safe: a disabled fuse is always readable (that is how it is
+ * flipped), so a read failure means either no fuses (env var honoured) or an
  * inaccessible binary (the probe's own exec then fails harmlessly).
- *
- * @param binaryPath - Path to the Electron binary
- * @returns whether the binary may be run as a Node CLI
  */
 export async function checkRunAsNodeFuse(binaryPath: string): Promise<RunAsNodeCheckResult> {
   try {

--- a/packages/electron-service/src/fuses.ts
+++ b/packages/electron-service/src/fuses.ts
@@ -78,9 +78,11 @@ export interface RunAsNodeCheckResult {
  * fuse is disabled the env var is ignored and the binary launches its real GUI,
  * so the probe must be skipped.
  *
- * Fail-open is safe: a disabled fuse is always readable (that is how it is
- * flipped), so a read failure means either no fuses (env var honoured) or an
- * inaccessible binary (the probe's own exec then fails harmlessly).
+ * Fail-open on a read error: usually that means no fuses (env var honoured) or
+ * an inaccessible binary (the probe's own exec then fails harmlessly). The rare
+ * exception is a fuse wire this @electron/fuses can't parse — a disabled fuse
+ * could then be probed and briefly flash the GUI — but failing closed would skip
+ * the probe for every unreadable-but-fine binary, defeating its purpose.
  */
 export async function checkRunAsNodeFuse(binaryPath: string): Promise<RunAsNodeCheckResult> {
   try {

--- a/packages/electron-service/src/fuses.ts
+++ b/packages/electron-service/src/fuses.ts
@@ -19,8 +19,6 @@ export async function checkInspectFuse(binaryPath: string): Promise<FuseCheckRes
   try {
     log.debug(`Checking EnableNodeCliInspectArguments fuse for: ${binaryPath}`);
 
-    // biome-ignore lint/suspicious/noTsIgnore: @electron/fuses types may not resolve in all environments (e.g. CI)
-    // @ts-ignore
     const { getCurrentFuseWire, FuseVersion, FuseV1Options, FuseState } = await import('@electron/fuses');
     const config = await getCurrentFuseWire(binaryPath);
 
@@ -88,8 +86,6 @@ export async function checkRunAsNodeFuse(binaryPath: string): Promise<RunAsNodeC
   try {
     log.debug(`Checking RunAsNode fuse for: ${binaryPath}`);
 
-    // biome-ignore lint/suspicious/noTsIgnore: @electron/fuses types may not resolve in all environments (e.g. CI)
-    // @ts-ignore
     const { getCurrentFuseWire, FuseVersion, FuseV1Options, FuseState } = await import('@electron/fuses');
     const config = await getCurrentFuseWire(binaryPath);
 

--- a/packages/electron-service/src/fuses.ts
+++ b/packages/electron-service/src/fuses.ts
@@ -65,3 +65,58 @@ export async function checkInspectFuse(binaryPath: string): Promise<FuseCheckRes
     };
   }
 }
+
+export interface RunAsNodeCheckResult {
+  canRunAsNode: boolean;
+  fuseValue?: number;
+  error?: string;
+}
+
+/**
+ * Checks whether the Electron binary may be run as a plain Node process (the
+ * `RunAsNode` fuse). The Chromium-version probe sets `ELECTRON_RUN_AS_NODE=1`
+ * and runs the binary with `-p`; if this fuse is disabled that env var is
+ * ignored and the binary would launch the real GUI, so the probe must not run.
+ *
+ * Failing open on an unreadable fuse is safe: a disabled `RunAsNode` fuse is
+ * always readable (that is how it gets flipped) and is caught below, so a read
+ * failure means either no fuses at all (the env var is honoured) or an
+ * inaccessible binary (the probe's own exec then fails harmlessly).
+ *
+ * @param binaryPath - Path to the Electron binary
+ * @returns whether the binary may be run as a Node CLI
+ */
+export async function checkRunAsNodeFuse(binaryPath: string): Promise<RunAsNodeCheckResult> {
+  try {
+    log.debug(`Checking RunAsNode fuse for: ${binaryPath}`);
+
+    // biome-ignore lint/suspicious/noTsIgnore: @electron/fuses types may not resolve in all environments (e.g. CI)
+    // @ts-ignore
+    const { getCurrentFuseWire, FuseVersion, FuseV1Options, FuseState } = await import('@electron/fuses');
+    const config = await getCurrentFuseWire(binaryPath);
+
+    if (!config) {
+      return { canRunAsNode: true };
+    }
+
+    if (config.version === FuseVersion.V1) {
+      const runAsNodeFuse = config[FuseV1Options.RunAsNode];
+      log.debug(`RunAsNode fuse value: ${runAsNodeFuse}`);
+
+      if (runAsNodeFuse === FuseState.DISABLE) {
+        log.warn('RunAsNode fuse is disabled - skipping Chromium version probe to avoid launching the app');
+        return { canRunAsNode: false, fuseValue: runAsNodeFuse };
+      }
+
+      return { canRunAsNode: true, fuseValue: runAsNodeFuse };
+    }
+
+    return { canRunAsNode: true };
+  } catch (error) {
+    log.debug(`Failed to check RunAsNode fuse: ${error instanceof Error ? error.message : String(error)}`);
+    return {
+      canRunAsNode: true,
+      error: `Could not verify fuse configuration: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -23,6 +23,7 @@ import type { Capabilities, Options, Services } from '@wdio/types';
 import getPort from 'get-port';
 import { SevereServiceError } from 'webdriverio';
 import { applyApparmorWorkaround } from './apparmor.js';
+import { probeChromiumVersion } from './binaryProbe.js';
 import {
   getChromedriverOptions,
   getChromeOptions,
@@ -254,16 +255,9 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
     await Promise.all(
       caps.map(async (cap) => {
         const electronVersion = cap.browserVersion || localElectronVersion || '';
-        const chromiumVersion = await getChromiumVersion(electronVersion);
-        if (!electronVersion) {
-          log.warn('Could not determine the Electron version under test');
-        } else if (chromiumVersion) {
-          log.info(`Found Electron v${electronVersion} with Chromedriver v${chromiumVersion}`);
-        } else {
-          log.warn(`Found Electron v${electronVersion}, but no matching Chromedriver version is known`);
-        }
+        // Map lookup first; a binary probe below fills this in when the map has no entry.
+        let chromiumVersion: string | undefined = await getChromiumVersion(electronVersion);
 
-        (cap as ElectronServiceCapabilities & Record<string, unknown>)['wdio:chromiumVersion'] = chromiumVersion;
         (cap as ElectronServiceCapabilities & Record<string, unknown>)['wdio:electronVersion'] = electronVersion;
 
         if (Number.parseInt(electronVersion.split('.')[0], 10) < 26 && !cap['wdio:chromedriverOptions']?.binary) {
@@ -352,6 +346,22 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
         if (appBinaryPath) {
           uniqueBinaryPaths.add(appBinaryPath);
         }
+
+        // Last resort — the Electron→Chromium map had no entry (nightly / fork, or a release newer
+        // than the bundled map when the online lookup is down). Ask the binary itself. (#578)
+        if (!chromiumVersion && electronVersion && appBinaryPath) {
+          chromiumVersion = await probeChromiumVersion(appBinaryPath);
+        }
+
+        if (!electronVersion) {
+          log.warn('Could not determine the Electron version under test');
+        } else if (chromiumVersion) {
+          log.info(`Found Electron v${electronVersion} with Chromedriver v${chromiumVersion}`);
+        } else {
+          log.warn(`Found Electron v${electronVersion}, but no matching Chromedriver version is known`);
+        }
+
+        (cap as ElectronServiceCapabilities & Record<string, unknown>)['wdio:chromiumVersion'] = chromiumVersion;
 
         cap.browserName = 'chrome';
         cap['goog:chromeOptions'] = getChromeOptions({ appBinaryPath, appArgs }, cap);

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -255,7 +255,6 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
     await Promise.all(
       caps.map(async (cap) => {
         const electronVersion = cap.browserVersion || localElectronVersion || '';
-        // Map lookup first; a binary probe below fills this in when the map has no entry.
         let chromiumVersion: string | undefined = await getChromiumVersion(electronVersion);
 
         (cap as ElectronServiceCapabilities & Record<string, unknown>)['wdio:electronVersion'] = electronVersion;
@@ -347,8 +346,7 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           uniqueBinaryPaths.add(appBinaryPath);
         }
 
-        // Last resort — the Electron→Chromium map had no entry (nightly / fork, or a release newer
-        // than the bundled map when the online lookup is down). Ask the binary itself. (#578)
+        // The map had no entry — ask the binary directly (#578).
         if (!chromiumVersion && electronVersion && appBinaryPath) {
           chromiumVersion = await probeChromiumVersion(appBinaryPath);
         }

--- a/packages/electron-service/src/launcher.ts
+++ b/packages/electron-service/src/launcher.ts
@@ -346,7 +346,7 @@ export default class ElectronLaunchService implements Services.ServiceInstance {
           uniqueBinaryPaths.add(appBinaryPath);
         }
 
-        // The map had no entry — ask the binary directly (#578).
+        // The map had no entry — probe the binary (see https://github.com/webdriverio/desktop-mobile/issues/578).
         if (!chromiumVersion && electronVersion && appBinaryPath) {
           chromiumVersion = await probeChromiumVersion(appBinaryPath);
         }

--- a/packages/electron-service/test/binaryProbe.spec.ts
+++ b/packages/electron-service/test/binaryProbe.spec.ts
@@ -73,4 +73,14 @@ describe('probeChromiumVersion', () => {
     expect(b).toBe('150.0.7871.129');
     expect(mockExecFile).toHaveBeenCalledTimes(1);
   });
+
+  it('should not cache a failed probe (retries on a later call)', async () => {
+    stubExecFile((cb) => cb(new Error('spawn ETIMEDOUT'), ''));
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBeUndefined();
+
+    // The binary recovered — a later call re-probes rather than returning the cached failure.
+    stubExecFile((cb) => cb(null, '150.0.7871.129\n'));
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBe('150.0.7871.129');
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/electron-service/test/binaryProbe.spec.ts
+++ b/packages/electron-service/test/binaryProbe.spec.ts
@@ -19,7 +19,6 @@ vi.mock('@wdio/native-utils', () => import('./mocks/native-utils.js'));
 
 import { probeChromiumVersion, resetProbeCache } from '../src/binaryProbe.js';
 
-// Drive the mocked execFile callback: `execFile(bin, args, opts, cb)`.
 const stubExecFile = (impl: (cb: (err: Error | null, stdout: string) => void) => void): void => {
   mockExecFile.mockImplementation(((_bin, _args, _opts, cb) => impl(cb)) as typeof execFileType);
 };

--- a/packages/electron-service/test/binaryProbe.spec.ts
+++ b/packages/electron-service/test/binaryProbe.spec.ts
@@ -1,0 +1,76 @@
+import type { execFile as execFileType } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExecFile, mockCheckRunAsNodeFuse } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockCheckRunAsNodeFuse: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: mockExecFile,
+  default: { execFile: mockExecFile },
+}));
+
+vi.mock('../src/fuses.js', () => ({
+  checkRunAsNodeFuse: mockCheckRunAsNodeFuse,
+}));
+
+vi.mock('@wdio/native-utils', () => import('./mocks/native-utils.js'));
+
+import { probeChromiumVersion, resetProbeCache } from '../src/binaryProbe.js';
+
+// Drive the mocked execFile callback: `execFile(bin, args, opts, cb)`.
+const stubExecFile = (impl: (cb: (err: Error | null, stdout: string) => void) => void): void => {
+  mockExecFile.mockImplementation(((_bin, _args, _opts, cb) => impl(cb)) as typeof execFileType);
+};
+
+describe('probeChromiumVersion', () => {
+  beforeEach(() => {
+    resetProbeCache();
+    mockCheckRunAsNodeFuse.mockResolvedValue({ canRunAsNode: true });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should resolve the Chromium version from the binary output', async () => {
+    stubExecFile((cb) => cb(null, '150.0.7871.129\n'));
+
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBe('150.0.7871.129');
+
+    const [binary, args, opts] = mockExecFile.mock.calls[0];
+    expect(binary).toBe('/app/electron');
+    expect(args).toEqual(['-p', 'process.versions.chrome']);
+    expect((opts as { env: NodeJS.ProcessEnv }).env.ELECTRON_RUN_AS_NODE).toBe('1');
+  });
+
+  it('should not run the binary when the RunAsNode fuse is disabled', async () => {
+    mockCheckRunAsNodeFuse.mockResolvedValue({ canRunAsNode: false });
+
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('should resolve undefined when the probe process errors (e.g. timeout)', async () => {
+    stubExecFile((cb) => cb(new Error('spawn ETIMEDOUT'), ''));
+
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBeUndefined();
+  });
+
+  it('should resolve undefined when the output is not a version', async () => {
+    stubExecFile((cb) => cb(null, 'not-a-version\n'));
+
+    await expect(probeChromiumVersion('/app/electron')).resolves.toBeUndefined();
+  });
+
+  it('should probe a given binary only once (cache per path)', async () => {
+    stubExecFile((cb) => cb(null, '150.0.7871.129\n'));
+
+    const [a, b] = await Promise.all([probeChromiumVersion('/app/electron'), probeChromiumVersion('/app/electron')]);
+
+    expect(a).toBe('150.0.7871.129');
+    expect(b).toBe('150.0.7871.129');
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/electron-service/test/fuses.spec.ts
+++ b/packages/electron-service/test/fuses.spec.ts
@@ -1,6 +1,6 @@
 import { FuseState, FuseV1Options, FuseVersion, getCurrentFuseWire } from '@electron/fuses';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { checkInspectFuse } from '../src/fuses.js';
+import { checkInspectFuse, checkRunAsNodeFuse } from '../src/fuses.js';
 
 vi.mock('@electron/fuses', () => ({
   FuseState: {
@@ -10,6 +10,7 @@ vi.mock('@electron/fuses', () => ({
     INHERIT: 144,
   },
   FuseV1Options: {
+    RunAsNode: 0,
     EnableNodeCliInspectArguments: 3,
   },
   FuseVersion: {
@@ -106,6 +107,58 @@ describe('fuses', () => {
       expect(result.canUseCdpBridge).toBe(true);
       expect(result.error).toContain('Could not verify fuse configuration');
       expect(result.error).toContain('string error');
+    });
+  });
+
+  describe('checkRunAsNodeFuse', () => {
+    it('should return canRunAsNode: true when no fuse config is found', async () => {
+      vi.mocked(getCurrentFuseWire).mockResolvedValue(null as never);
+
+      const result = await checkRunAsNodeFuse('/path/to/electron');
+
+      expect(result).toEqual({ canRunAsNode: true });
+    });
+
+    it('should return canRunAsNode: true when the fuse is enabled', async () => {
+      vi.mocked(getCurrentFuseWire).mockResolvedValue({
+        version: FuseVersion.V1,
+        [FuseV1Options.RunAsNode]: FuseState.ENABLE,
+      } as any);
+
+      const result = await checkRunAsNodeFuse('/path/to/electron');
+
+      expect(result).toEqual({ canRunAsNode: true, fuseValue: FuseState.ENABLE });
+    });
+
+    it('should return canRunAsNode: false when the fuse is disabled', async () => {
+      vi.mocked(getCurrentFuseWire).mockResolvedValue({
+        version: FuseVersion.V1,
+        [FuseV1Options.RunAsNode]: FuseState.DISABLE,
+      } as any);
+
+      const result = await checkRunAsNodeFuse('/path/to/electron');
+
+      expect(result.canRunAsNode).toBe(false);
+      expect(result.fuseValue).toBe(FuseState.DISABLE);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return canRunAsNode: true when no V1 fuses are present', async () => {
+      vi.mocked(getCurrentFuseWire).mockResolvedValue({} as any);
+
+      const result = await checkRunAsNodeFuse('/path/to/electron');
+
+      expect(result).toEqual({ canRunAsNode: true });
+    });
+
+    it('should fail open (canRunAsNode: true) with an error message when reading fuses fails', async () => {
+      vi.mocked(getCurrentFuseWire).mockRejectedValue(new Error('Failed to read binary'));
+
+      const result = await checkRunAsNodeFuse('/path/to/electron');
+
+      expect(result.canRunAsNode).toBe(true);
+      expect(result.error).toContain('Could not verify fuse configuration');
+      expect(result.error).toContain('Failed to read binary');
     });
   });
 });

--- a/packages/electron-service/test/integration/launcher.browser.integration.spec.ts
+++ b/packages/electron-service/test/integration/launcher.browser.integration.spec.ts
@@ -22,6 +22,7 @@ vi.mock('../../src/appBuildInfo.js', () => ({ getAppBuildInfo: vi.fn() }));
 vi.mock('../../src/binaryPath.js', () => ({ getBinaryPath: vi.fn() }));
 vi.mock('../../src/electronVersion.js', () => ({ getElectronVersion: vi.fn() }));
 vi.mock('../../src/versions.js', () => ({ getChromiumVersion: vi.fn() }));
+vi.mock('../../src/binaryProbe.js', () => ({ probeChromiumVersion: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../../src/pathResolver.js', () => ({ resolveAppPaths: vi.fn() }));
 vi.mock('../../src/apparmor.js', () => ({ applyApparmorWorkaround: vi.fn() }));
 vi.mock('../../src/diagnostics.js', () => ({ diagnoseElectronEnvironment: vi.fn().mockResolvedValue([]) }));
@@ -50,6 +51,7 @@ import getPort from 'get-port';
 import { applyApparmorWorkaround } from '../../src/apparmor.js';
 import { getAppBuildInfo } from '../../src/appBuildInfo.js';
 import { getBinaryPath } from '../../src/binaryPath.js';
+import { probeChromiumVersion } from '../../src/binaryProbe.js';
 import { ElectronCdpBridge } from '../../src/bridge.js';
 import { getElectronVersion } from '../../src/electronVersion.js';
 import ElectronLaunchService from '../../src/launcher.js';
@@ -99,6 +101,7 @@ describe('launcher → worker handshake (browser mode)', () => {
 
     expect(getElectronVersion).not.toHaveBeenCalled();
     expect(getChromiumVersion).not.toHaveBeenCalled();
+    expect(probeChromiumVersion).not.toHaveBeenCalled();
     expect(resolveAppPaths).not.toHaveBeenCalled();
     expect(getBinaryPath).not.toHaveBeenCalled();
     expect(getAppBuildInfo).not.toHaveBeenCalled();

--- a/packages/electron-service/test/launcher.spec.ts
+++ b/packages/electron-service/test/launcher.spec.ts
@@ -16,6 +16,7 @@ let options: ElectronServiceOptions;
 let getBinaryPath: Mock<() => Promise<BinaryPathResult>>;
 let getAppBuildInfo: Mock<() => Promise<AppBuildInfo>>;
 let getElectronVersion: Mock<() => Promise<string>>;
+let probeChromiumVersion: Mock<() => Promise<string | undefined>>;
 let readPackageUp: Mock<
   (options?: {
     cwd?: string;
@@ -65,6 +66,7 @@ vi.mock('@wdio/native-utils', async () => {
 vi.mock('../src/appBuildInfo.js', () => ({ getAppBuildInfo: vi.fn() }));
 vi.mock('../src/binaryPath.js', () => ({ getBinaryPath: vi.fn() }));
 vi.mock('../src/electronVersion.js', () => ({ getElectronVersion: vi.fn() }));
+vi.mock('../src/binaryProbe.js', () => ({ probeChromiumVersion: vi.fn() }));
 
 vi.mock('get-port', async () => {
   return {
@@ -83,6 +85,10 @@ beforeEach(async () => {
   getBinaryPath = binaryPathMod.getBinaryPath as Mock<() => Promise<BinaryPathResult>>;
   getAppBuildInfo = appBuildInfoMod.getAppBuildInfo as Mock<() => Promise<AppBuildInfo>>;
   getElectronVersion = electronVersionMod.getElectronVersion as Mock<() => Promise<string>>;
+  const binaryProbeMod = await import('../src/binaryProbe.js');
+  probeChromiumVersion = binaryProbeMod.probeChromiumVersion as Mock<() => Promise<string | undefined>>;
+  // Default: the probe finds nothing, so the map remains the sole resolver unless a test overrides it.
+  probeChromiumVersion.mockResolvedValue(undefined);
   readPackageUp = nativeUtils.readPackageUp as Mock<
     (
       ...args: unknown[]
@@ -579,6 +585,41 @@ describe('Electron Launch Service', () => {
           'wdio:electronVersion': 'some-version',
           'wdio:enforceWebDriverClassic': true,
         });
+      });
+
+      it('should resolve the Chromium version by probing the binary when the map has no entry', async () => {
+        // 'some-version' is not in the headers map, so onPrepare falls back to probing the binary.
+        probeChromiumVersion.mockResolvedValueOnce('150.0.7871.129');
+        const capabilities: WebdriverIO.Capabilities[] = [
+          {
+            browserName: 'electron',
+            browserVersion: 'some-version',
+          },
+        ];
+        await instance?.onPrepare({} as never, capabilities);
+        expect(probeChromiumVersion).toHaveBeenCalledWith('workspace/my-test-app/dist/my-test-app');
+        expect(capabilities[0]).toEqual({
+          browserName: 'chrome',
+          browserVersion: '150.0.7871.129',
+          'goog:chromeOptions': {
+            args: [],
+            binary: 'workspace/my-test-app/dist/my-test-app',
+            windowTypes: ['app', 'webview'],
+          },
+          'wdio:chromedriverOptions': {},
+          'wdio:electronServiceOptions': {},
+          'wdio:chromiumVersion': '150.0.7871.129',
+          'wdio:electronVersion': 'some-version',
+          'wdio:enforceWebDriverClassic': true,
+        });
+      });
+
+      it('should not probe the binary when the map resolves the Chromium version', async () => {
+        (getElectronVersion as Mock).mockResolvedValueOnce('26.0.0');
+        const capabilities: WebdriverIO.Capabilities[] = [{ browserName: 'electron' }];
+        await instance?.onPrepare({} as never, capabilities);
+        expect((capabilities[0] as Record<string, unknown>)['wdio:chromiumVersion']).toBe('116.0.5845.82');
+        expect(probeChromiumVersion).not.toHaveBeenCalled();
       });
 
       it('should use the Electron version from the local package dependencies when browserVersion is not provided', async () => {

--- a/packages/native-utils/src/log.ts
+++ b/packages/native-utils/src/log.ts
@@ -12,6 +12,7 @@ export type LogArea =
   | 'utils'
   | 'e2e'
   | 'fuses'
+  | 'probe'
   | 'window'
   | 'triggerDeeplink';
 


### PR DESCRIPTION
Closes #578.

## Problem

`getChromiumVersion` (`versions.ts`) maps the **Electron** version to a **Chromium** version via `electronjs.org/headers` with an `electron-to-chromium` fallback, and returns `undefined` when neither has the version. `onPrepare` then throws `CHROMIUM_VERSION_NOT_FOUND_ERROR` — even though Electron is installed and its version resolved fine; only the *Chromium mapping* failed. Reachable cases:

- **Offline + `electron-nightly`** — the bundled `electron-to-chromium` map has **zero** nightly keys, so any fetch failure (air-gapped CI, proxy) throws for every nightly user.
- **Forks with custom versions** (`2.0.0-mycompany`).
- **Any Electron newer than the pinned `electron-to-chromium`, when the fetch fails.**

## Fix — ask the binary

With `ELECTRON_RUN_AS_NODE=1` an Electron binary runs as a Node CLI, so `<binary> -p process.versions.chrome` reports the Chromium version **directly** (fast, no GUI; `-p` doesn't load the app's main script). It's a **last resort** — only when the map misses and a binary path is resolved — so the order is unchanged: `cap.browserVersion` → local Electron version + map → probe.

| file | change |
|---|---|
| `src/fuses.ts` | `checkRunAsNodeFuse` (mirrors `checkInspectFuse`) — if the RunAsNode fuse is **disabled**, `ELECTRON_RUN_AS_NODE` is ignored and `-p` would launch the real GUI, so the probe is skipped. Fail-open is safe (a disabled fuse is always readable). |
| `src/binaryProbe.ts` *(new)* | `probeChromiumVersion` — fuse-gated, `execFile` with a hard timeout, cached per binary path; `undefined` on any failure → caller falls through to the existing error. |
| `src/launcher.ts` | the map lookup stays put; the probe + `wdio:chromiumVersion` stamp are deferred until after the binary path is resolved. |
| `native-utils/src/log.ts` | add `'probe'` log area. |

Neighbouring PR #577 (merged) already resolved the *Electron* version from a dist-tag; this is the Chromium-side follow-on. (The issue's cited line numbers/strings had drifted — the throw is now `CHROMIUM_VERSION_NOT_FOUND_ERROR`, which already differentiates the two failure cases.)

## Tests

- **Unit** — the probe module (fuse-disabled → no exec/no GUI; valid/timeout/malformed; cache dedupe), the RunAsNode fuse check, the launcher wiring (probe fills the version on a map-miss; **not called** on a map-hit), and the browser-mode skip. All green (557 unit + 18 integration).
- **Package test (Flavour B)** — `electron-builder-app-esm/wdio.probe.conf.ts` forces a map-miss with a fork `browserVersion: '1000.0.0-probe'` + an explicit binary path (resolved via `getElectronBinaryPath`), so the session **only boots if the probe reads Chromium off the real packaged binary**. Runs in the existing `package-electron-matrix`.
- **No e2e** — the probe is a fallback that a normal e2e (map resolves) would never exercise.

## Verification
- `pnpm --filter @wdio/electron-service test` (89% coverage) + `test:integration` — green.
- typecheck + Biome — clean.
- The **package test can only be validated in CI** (needs a real Electron build + session); flagging for review there, as with the docker package tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URC1fN1sFWsKjemfD8gDmS