### PR TITLE
feat(tauri): match msedgedriver to a fixed-version WebView2 runtime (#539)

### DIFF
--- a/packages/tauri-service/docs/edge-webdriver-windows.md
+++ b/packages/tauri-service/docs/edge-webdriver-windows.md
@@ -75,6 +75,48 @@ If mismatch detected:
 - Caches in temp directory: `%TEMP%\msedgedriver\{majorVersion}\`
 - Adds to process PATH for test execution
 
+## Fixed-version WebView2 runtimes
+
+By default the service matches msedgedriver to the machine's **Evergreen** WebView2 runtime (read from the registry). But a Tauri app can ship against a **fixed-version WebView2 runtime** — a supported distribution mode (`bundle.windows.webviewInstallMode: "fixedRuntime"`, or the `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` environment variable). When the app renders with a fixed runtime that differs from the installed Evergreen, matching against Evergreen downloads the wrong driver and session creation fails:
+
+```
+session not created: This version of Microsoft Edge WebDriver only supports Microsoft Edge version 150
+Current browser version is 149.0.4022.98 ... tauri-e2e-app.exe
+```
+
+The service resolves the target version in this precedence order:
+
+1. **Explicit pin** — the `edgeDriverVersion` service option, or the `EDGEDRIVER_VERSION` environment variable, is used as the exact msedgedriver version verbatim (a CI escape hatch for the next Evergreen drift that breaks automation).
+2. **Fixed-version runtime folder** — if `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` is set, the runtime version is read from the `msedgewebview2.exe` in that folder, and the driver is matched to it. This is read from the service `env` option first, then `process.env`, mirroring what the app actually receives.
+3. **Evergreen** — the installed runtime from the registry (the default, and the canary that catches runtime regressions).
+
+### Pin the exact driver version
+
+```javascript
+services: [
+  ['tauri', {
+    application: './dist/my-app.exe',
+    edgeDriverVersion: '149.0.4022.98', // or set EDGEDRIVER_VERSION in the environment
+  }]
+]
+```
+
+### Drive a fixed-version runtime
+
+```javascript
+services: [
+  ['tauri', {
+    application: './dist/my-app.exe',
+    env: {
+      // The app renders with this runtime; the driver is matched to it automatically.
+      WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: 'C:\\path\\to\\fixed-version-runtime',
+    },
+  }]
+]
+```
+
+> Windows-only. macOS (WKWebView) and Linux (WebKitGTK) have no separately-versioned driver to mismatch.
+
 ## Troubleshooting
 
 ### "Could not detect Edge version"
@@ -144,6 +186,12 @@ interface TauriServiceOptions {
    * @platform Windows only
    */
   autoDownloadEdgeDriver?: boolean;
+  /**
+   * Pin the exact msedgedriver version to download, bypassing runtime detection.
+   * Also honoured via the EDGEDRIVER_VERSION environment variable.
+   * @platform Windows only
+   */
+  edgeDriverVersion?: string;
 }
 ```
 

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -1,6 +1,6 @@
 import { exec, execFile } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -86,6 +86,112 @@ export async function detectWebView2VersionFromBinary(binaryPath?: string): Prom
     }
   } catch (error) {
     log.debug(`Could not extract version from binary: ${error}`);
+  }
+
+  return undefined;
+}
+
+/** Read a Windows PE file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
+async function readFileVersion(filePath: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-Command', '(Get-Item $args[0]).VersionInfo.FileVersion', filePath],
+      { encoding: 'utf8', timeout: 5000 },
+    );
+    const version = stdout.trim();
+    if (/^\d+\.\d+\.\d+/.test(version)) {
+      return version;
+    }
+  } catch (error) {
+    log.debug(`Could not read file version from ${filePath}: ${error}`);
+  }
+  return undefined;
+}
+
+const FIXED_RUNTIME_EXE = 'msedgewebview2.exe';
+const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
+
+/**
+ * Resolve the WebView2 runtime version an app is pinned to via a fixed-version runtime folder
+ * (`WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`). The folder holds `msedgewebview2.exe`, whose FileVersion
+ * is the runtime version; some layouts nest it under a versioned subdir, so fall back to scanning.
+ * Windows-only; returns undefined off Windows or when the runtime binary can't be found/read.
+ */
+export async function detectFixedRuntimeVersion(folder?: string): Promise<string | undefined> {
+  if (process.platform !== 'win32' || !folder) {
+    return undefined;
+  }
+
+  const direct = join(folder, FIXED_RUNTIME_EXE);
+  if (existsSync(direct)) {
+    return readFileVersion(direct);
+  }
+
+  try {
+    for (const entry of readdirSync(folder)) {
+      const nested = join(folder, entry, FIXED_RUNTIME_EXE);
+      if (VERSION_DIR.test(entry) && existsSync(nested)) {
+        return readFileVersion(nested);
+      }
+    }
+  } catch {
+    // Folder unreadable — fall through to undefined.
+  }
+
+  return undefined;
+}
+
+export type EdgeVersionSource = 'override' | 'fixed-runtime' | 'evergreen';
+
+export interface ResolveEdgeVersionOptions {
+  /** Explicit msedgedriver version pin (service option `edgeDriverVersion`). */
+  edgeDriverVersion?: string;
+  /** Env passed to the driver/app process (service option `env`); mirrors the app's runtime env. */
+  env?: Record<string, string>;
+}
+
+export interface ResolvedEdgeVersion {
+  /** The Edge/WebView2 runtime version, or — when `source` is `'override'` — the exact driver version. */
+  version: string;
+  source: EdgeVersionSource;
+}
+
+const WEBVIEW2_FOLDER_ENV = 'WEBVIEW2_BROWSER_EXECUTABLE_FOLDER';
+const EDGEDRIVER_VERSION_ENV = 'EDGEDRIVER_VERSION';
+
+/**
+ * Decide which Edge/WebView2 version msedgedriver should match, in precedence order:
+ *   1. an explicit driver pin (`edgeDriverVersion` option / `EDGEDRIVER_VERSION`) — used verbatim;
+ *   2. a fixed-version runtime folder (`WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`) — the app renders with
+ *      that runtime, not the machine's Evergreen, so its version is what the driver must match;
+ *   3. the Evergreen runtime from the registry (the default, and the canary for runtime regressions).
+ * The folder env is read from `options.env` first, then `process.env`, matching how the app receives
+ * it (`{ ...process.env, ...options.env }`). Returns undefined when nothing resolves.
+ */
+export async function resolveTargetEdgeVersion(
+  options: ResolveEdgeVersionOptions = {},
+): Promise<ResolvedEdgeVersion | undefined> {
+  const override = options.edgeDriverVersion ?? process.env[EDGEDRIVER_VERSION_ENV];
+  if (override) {
+    return { version: override, source: 'override' };
+  }
+
+  const fixedFolder = options.env?.[WEBVIEW2_FOLDER_ENV] ?? process.env[WEBVIEW2_FOLDER_ENV];
+  if (fixedFolder) {
+    const version = await detectFixedRuntimeVersion(fixedFolder);
+    if (version) {
+      return { version, source: 'fixed-runtime' };
+    }
+    log.warn(
+      `${WEBVIEW2_FOLDER_ENV} is set (${fixedFolder}) but no readable ${FIXED_RUNTIME_EXE} was found ` +
+        'in it — falling back to the Evergreen runtime version.',
+    );
+  }
+
+  const evergreen = await detectWebView2Version();
+  if (evergreen) {
+    return { version: evergreen, source: 'evergreen' };
   }
 
   return undefined;
@@ -234,9 +340,11 @@ async function getDriverVersionForEdge(edgeVersion: string): Promise<string> {
 }
 
 /**
- * Download msedgedriver for a specific Edge version
+ * Download msedgedriver for a specific Edge version.
+ * When `exactVersion` is set, `edgeVersion` is treated as the exact driver version and the
+ * Microsoft `LATEST_RELEASE_<major>` lookup is skipped (used for an explicit `edgeDriverVersion` pin).
  */
-export async function downloadMsEdgeDriver(edgeVersion: string): Promise<string> {
+export async function downloadMsEdgeDriver(edgeVersion: string, exactVersion = false): Promise<string> {
   const majorVersion = getMajorVersion(edgeVersion);
   // Use random temp directory name to prevent symlink attacks
   const randomSuffix = randomBytes(8).toString('hex');
@@ -247,8 +355,8 @@ export async function downloadMsEdgeDriver(edgeVersion: string): Promise<string>
   // Create directory with restrictive permissions (owner-only access)
   mkdirSync(downloadDir, { recursive: true, mode: 0o700 });
 
-  // Get the correct driver version from Microsoft
-  const driverVersion = await getDriverVersionForEdge(edgeVersion);
+  // Get the correct driver version from Microsoft (unless an exact version was pinned).
+  const driverVersion = exactVersion ? edgeVersion : await getDriverVersionForEdge(edgeVersion);
 
   // Create PowerShell script for downloading
   const psScript = `
@@ -340,20 +448,25 @@ try {
  * Ensure msedgedriver is available and matches Edge version
  * This is the main entry point for Edge driver management
  */
-export async function ensureMsEdgeDriver(_tauriBinaryPath?: string, autoDownload = true): Promise<EdgeDriverResult> {
+export async function ensureMsEdgeDriver(
+  _tauriBinaryPath?: string,
+  autoDownload = true,
+  options: ResolveEdgeVersionOptions = {},
+): Promise<EdgeDriverResult> {
   if (process.platform !== 'win32') {
     return Ok({ method: 'skipped' as const });
   }
 
   log.info('Checking Edge WebDriver compatibility...');
 
-  const edgeVersion = await detectWebView2Version();
-  if (!edgeVersion) {
-    log.warn('Could not detect WebView2 runtime version - skipping driver check');
+  const resolved = await resolveTargetEdgeVersion(options);
+  if (!resolved) {
+    log.warn('Could not determine the WebView2 runtime version - skipping driver check');
     return Ok({ method: 'skipped' as const });
   }
 
-  log.info(`Detected WebView2 runtime version: ${edgeVersion}`);
+  const { version: edgeVersion, source } = resolved;
+  log.info(`Target Edge/WebView2 version ${edgeVersion} (source: ${source})`);
   const edgeMajor = getMajorVersion(edgeVersion);
 
   const existing = await findMsEdgeDriver();
@@ -376,7 +489,7 @@ export async function ensureMsEdgeDriver(_tauriBinaryPath?: string, autoDownload
   if (autoDownload) {
     try {
       log.info(`Attempting to download msedgedriver ${edgeVersion}...`);
-      const downloadedPath = await downloadMsEdgeDriver(edgeVersion);
+      const downloadedPath = await downloadMsEdgeDriver(edgeVersion, source === 'override');
 
       process.env.PATH = `${join(downloadedPath, '..')}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
 

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -91,7 +91,7 @@ export async function detectWebView2VersionFromBinary(binaryPath?: string): Prom
   return undefined;
 }
 
-/** Read a Windows PE file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
+/** Read a Windows file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
 async function readFileVersion(filePath: string): Promise<string | undefined> {
   try {
     // Embed the path in the -Command string (single quotes doubled): a trailing argv token does
@@ -162,9 +162,9 @@ export async function detectFixedRuntimeVersion(folder?: string): Promise<string
 export type EdgeVersionSource = 'override' | 'fixed-runtime' | 'evergreen';
 
 export interface ResolveEdgeVersionOptions {
-  /** Explicit msedgedriver version pin (service option `edgeDriverVersion`). */
+  /** Explicit msedgedriver version pin. */
   edgeDriverVersion?: string;
-  /** Env passed to the driver/app process (service option `env`); mirrors the app's runtime env. */
+  /** The app's runtime env; the resolver reads `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` from it. */
   env?: Record<string, string>;
 }
 
@@ -183,8 +183,8 @@ const EDGEDRIVER_VERSION_ENV = 'EDGEDRIVER_VERSION';
  *   2. a fixed-version runtime folder (`WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`) — the app renders with
  *      that runtime, not the machine's Evergreen, so its version is what the driver must match;
  *   3. the Evergreen runtime from the registry (the default).
- * The folder env is read from `options.env` first, then `process.env`, matching how the app receives
- * it (`{ ...process.env, ...options.env }`). Returns undefined when nothing resolves.
+ * The folder env is read with the app's own precedence — `options.env` over `process.env`
+ * (`{ ...process.env, ...options.env }`) — so the resolver sees the folder the app actually uses.
  */
 export async function resolveTargetEdgeVersion(
   options: ResolveEdgeVersionOptions = {},
@@ -359,7 +359,7 @@ async function getDriverVersionForEdge(edgeVersion: string): Promise<string> {
 /**
  * Download msedgedriver for a specific Edge version.
  * When `exactVersion` is set, `edgeVersion` is treated as the exact driver version and the
- * Microsoft `LATEST_RELEASE_<major>` lookup is skipped (used for an explicit `edgeDriverVersion` pin).
+ * Microsoft `LATEST_RELEASE_<major>` lookup is skipped.
  */
 export async function downloadMsEdgeDriver(edgeVersion: string, exactVersion = false): Promise<string> {
   const majorVersion = getMajorVersion(edgeVersion);

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -59,38 +59,6 @@ export async function detectWebView2Version(): Promise<string | undefined> {
   }
 }
 
-/**
- * Detect WebView2 version from Tauri binary (legacy method - may not work correctly)
- * Tauri apps use an embedded/fixed WebView2 runtime, not the system Edge
- * @deprecated Use detectWebView2Version() instead for more reliable detection
- */
-export async function detectWebView2VersionFromBinary(binaryPath?: string): Promise<string | undefined> {
-  if (process.platform !== 'win32' || !binaryPath) {
-    return undefined;
-  }
-
-  try {
-    const { stdout } = await execFileAsync(
-      'powershell.exe',
-      ['-Command', '(Get-Item $args[0]).VersionInfo.FileVersion', binaryPath],
-      {
-        encoding: 'utf8',
-        timeout: 5000,
-      },
-    );
-
-    const version = stdout.trim();
-    if (version && /^\d+\.\d+\.\d+/.test(version)) {
-      log.debug(`Detected file version ${version} from Tauri binary ${binaryPath}`);
-      return version;
-    }
-  } catch (error) {
-    log.debug(`Could not extract version from binary: ${error}`);
-  }
-
-  return undefined;
-}
-
 /** Read a Windows file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
 async function readFileVersion(filePath: string): Promise<string | undefined> {
   try {
@@ -102,9 +70,10 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
       ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
       { encoding: 'utf8', timeout: 5000 },
     );
-    const version = stdout.trim();
-    if (/^\d+\.\d+\.\d+/.test(version)) {
-      return version;
+    // Return only the numeric prefix — FileVersion can carry trailing text (e.g. "150.0.0 (rc)").
+    const match = stdout.trim().match(/^\d+\.\d+\.\d+(?:\.\d+)?/);
+    if (match) {
+      return match[0];
     }
   } catch (error) {
     log.debug(`Could not read file version from ${filePath}: ${error}`);
@@ -114,8 +83,11 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
 
 const FIXED_RUNTIME_EXE = 'msedgewebview2.exe';
 const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
+/** A complete, injection-safe version string (digits and dots only, 2–4 parts). */
+const VERSION_RE = /^\d+(?:\.\d+){1,3}$/;
 
-function compareVersionsDesc(a: string, b: string): number {
+/** Order dotted numeric versions highest-first (an `Array#sort` comparator). */
+export function compareVersionsDesc(a: string, b: string): number {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
@@ -191,7 +163,12 @@ export async function resolveTargetEdgeVersion(
 ): Promise<ResolvedEdgeVersion | undefined> {
   const override = options.edgeDriverVersion ?? process.env[EDGEDRIVER_VERSION_ENV];
   if (override) {
-    return { version: override, source: 'override' };
+    if (VERSION_RE.test(override)) {
+      return { version: override, source: 'override' };
+    }
+    log.warn(
+      `Ignoring edgeDriverVersion/${EDGEDRIVER_VERSION_ENV} "${override}" — expected a numeric version like 149.0.4022.98.`,
+    );
   }
 
   const fixedFolder = options.env?.[WEBVIEW2_FOLDER_ENV] ?? process.env[WEBVIEW2_FOLDER_ENV];
@@ -361,7 +338,10 @@ async function getDriverVersionForEdge(edgeVersion: string): Promise<string> {
  * When `exactVersion` is set, `edgeVersion` is treated as the exact driver version and the
  * Microsoft `LATEST_RELEASE_<major>` lookup is skipped.
  */
-export async function downloadMsEdgeDriver(edgeVersion: string, exactVersion = false): Promise<string> {
+export async function downloadMsEdgeDriver(
+  edgeVersion: string,
+  exactVersion = false,
+): Promise<{ path: string; version: string }> {
   const majorVersion = getMajorVersion(edgeVersion);
   // Use random temp directory name to prevent symlink attacks
   const randomSuffix = randomBytes(8).toString('hex');
@@ -375,12 +355,13 @@ export async function downloadMsEdgeDriver(edgeVersion: string, exactVersion = f
   // Get the correct driver version from Microsoft (unless an exact version was pinned).
   const driverVersion = exactVersion ? edgeVersion : await getDriverVersionForEdge(edgeVersion);
 
-  // Create PowerShell script for downloading
+  // Create PowerShell script for downloading. Double any embedded single quotes so a version can't
+  // break out of the string literal (mirrors readFileVersion; belt-and-suspenders over VERSION_RE).
   const psScript = `
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'  # Faster downloads
-$driverVersion = '${driverVersion}'
-$edgeVersion = '${edgeVersion}'
+$driverVersion = '${driverVersion.replace(/'/g, "''")}'
+$edgeVersion = '${edgeVersion.replace(/'/g, "''")}'
 $downloadDir = '${downloadDir.replace(/\\/g, '\\\\')}'
 $driverPath = '${driverPath.replace(/\\/g, '\\\\')}'
 
@@ -441,7 +422,7 @@ try {
 
     if (existsSync(driverPath)) {
       log.info(`Successfully downloaded msedgedriver ${driverVersion} (for Edge ${edgeVersion}) to ${driverPath}`);
-      return driverPath;
+      return { path: driverPath, version: driverVersion };
     }
 
     throw new Error('Download completed but driver not found');
@@ -509,14 +490,14 @@ export async function ensureMsEdgeDriver(
   if (autoDownload) {
     try {
       log.info(`Attempting to download msedgedriver ${edgeVersion}...`);
-      const downloadedPath = await downloadMsEdgeDriver(edgeVersion, source === 'override');
+      const downloaded = await downloadMsEdgeDriver(edgeVersion, source === 'override');
 
-      process.env.PATH = `${join(downloadedPath, '..')}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
+      process.env.PATH = `${join(downloaded.path, '..')}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
 
-      log.info(`✅ Downloaded and configured msedgedriver ${edgeVersion}`);
+      log.info(`✅ Downloaded and configured msedgedriver ${downloaded.version}`);
       return Ok({
-        driverPath: downloadedPath,
-        driverVersion: edgeVersion,
+        driverPath: downloaded.path,
+        driverVersion: downloaded.version,
         edgeVersion,
         method: 'downloaded' as const,
       });

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -112,7 +112,6 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
 const FIXED_RUNTIME_EXE = 'msedgewebview2.exe';
 const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
 
-/** Order dotted numeric versions highest-first (use as an `Array#sort` comparator). */
 function compareVersionsDesc(a: string, b: string): number {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
@@ -180,7 +179,7 @@ const EDGEDRIVER_VERSION_ENV = 'EDGEDRIVER_VERSION';
  *   1. an explicit driver pin (`edgeDriverVersion` option / `EDGEDRIVER_VERSION`) — used verbatim;
  *   2. a fixed-version runtime folder (`WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`) — the app renders with
  *      that runtime, not the machine's Evergreen, so its version is what the driver must match;
- *   3. the Evergreen runtime from the registry (the default, and the canary for runtime regressions).
+ *   3. the Evergreen runtime from the registry (the default).
  * The folder env is read from `options.env` first, then `process.env`, matching how the app receives
  * it (`{ ...process.env, ...options.env }`). Returns undefined when nothing resolves.
  */

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -112,6 +112,19 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
 const FIXED_RUNTIME_EXE = 'msedgewebview2.exe';
 const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
 
+/** Order dotted numeric versions highest-first (use as an `Array#sort` comparator). */
+function compareVersionsDesc(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
 /**
  * Resolve the WebView2 runtime version an app is pinned to via a fixed-version runtime folder
  * (`WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`). The folder holds `msedgewebview2.exe`, whose FileVersion
@@ -129,11 +142,13 @@ export async function detectFixedRuntimeVersion(folder?: string): Promise<string
   }
 
   try {
-    for (const entry of readdirSync(folder)) {
-      const nested = join(folder, entry, FIXED_RUNTIME_EXE);
-      if (VERSION_DIR.test(entry) && existsSync(nested)) {
-        return readFileVersion(nested);
-      }
+    // Several `<version>/msedgewebview2.exe` subdirs can coexist; pick the highest so selection is
+    // deterministic rather than dependent on readdir order (which could resolve a stale runtime).
+    const [newest] = readdirSync(folder)
+      .filter((entry) => VERSION_DIR.test(entry) && existsSync(join(folder, entry, FIXED_RUNTIME_EXE)))
+      .sort(compareVersionsDesc);
+    if (newest) {
+      return readFileVersion(join(folder, newest, FIXED_RUNTIME_EXE));
     }
   } catch {
     // Folder unreadable — fall through to undefined.
@@ -471,9 +486,12 @@ export async function ensureMsEdgeDriver(
 
   const existing = await findMsEdgeDriver();
   if (existing.path && existing.version) {
-    const driverMajor = getMajorVersion(existing.version);
+    // An explicit pin (`source: 'override'`) must match the driver exactly; the runtime-derived
+    // paths only need the shared major, since Edge and its driver drift in the lower version parts.
+    const compatible =
+      source === 'override' ? existing.version === edgeVersion : getMajorVersion(existing.version) === edgeMajor;
 
-    if (driverMajor === edgeMajor) {
+    if (compatible) {
       log.info(`✅ msedgedriver ${existing.version} matches Edge ${edgeVersion}`);
       return Ok({
         driverPath: existing.path,

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -62,8 +62,8 @@ export async function detectWebView2Version(): Promise<string | undefined> {
 /** Read a Windows file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
 async function readFileVersion(filePath: string): Promise<string | undefined> {
   try {
-    // Embed the path in the -Command string (single quotes doubled): a trailing argv token does
-    // not populate $args under -Command, so `(Get-Item $args[0])` reads an empty path and fails.
+    // Embed the path in the -Command string: a trailing argv token does not populate $args under
+    // -Command, so `(Get-Item $args[0])` reads an empty path and fails.
     const psPath = filePath.replace(/'/g, "''");
     const { stdout } = await execFileAsync(
       'powershell.exe',
@@ -83,10 +83,10 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
 
 const FIXED_RUNTIME_EXE = 'msedgewebview2.exe';
 const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
-/** A complete, injection-safe version string (digits and dots only, 2–4 parts). */
+/** A complete, injection-safe version string. */
 const VERSION_RE = /^\d+(?:\.\d+){1,3}$/;
 
-/** Order dotted numeric versions highest-first (an `Array#sort` comparator). */
+/** Order dotted numeric versions highest-first. */
 export function compareVersionsDesc(a: string, b: string): number {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
@@ -116,8 +116,8 @@ export async function detectFixedRuntimeVersion(folder?: string): Promise<string
   }
 
   try {
-    // Several `<version>/msedgewebview2.exe` subdirs can coexist; pick the highest so selection is
-    // deterministic rather than dependent on readdir order (which could resolve a stale runtime).
+    // Several `<version>/msedgewebview2.exe` subdirs can coexist; pick the highest so a stale
+    // runtime can't win on readdir order.
     const [newest] = readdirSync(folder)
       .filter((entry) => VERSION_DIR.test(entry) && existsSync(join(folder, entry, FIXED_RUNTIME_EXE)))
       .sort(compareVersionsDesc);
@@ -356,7 +356,7 @@ export async function downloadMsEdgeDriver(
   const driverVersion = exactVersion ? edgeVersion : await getDriverVersionForEdge(edgeVersion);
 
   // Create PowerShell script for downloading. Double any embedded single quotes so a version can't
-  // break out of the string literal (mirrors readFileVersion; belt-and-suspenders over VERSION_RE).
+  // break out of the string literal (belt-and-suspenders over VERSION_RE).
   const psScript = `
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'  # Faster downloads

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -94,9 +94,12 @@ export async function detectWebView2VersionFromBinary(binaryPath?: string): Prom
 /** Read a Windows PE file's FileVersion (e.g. `150.0.4022.98`). Windows-only. */
 async function readFileVersion(filePath: string): Promise<string | undefined> {
   try {
+    // Embed the path in the -Command string (single quotes doubled): a trailing argv token does
+    // not populate $args under -Command, so `(Get-Item $args[0])` reads an empty path and fails.
+    const psPath = filePath.replace(/'/g, "''");
     const { stdout } = await execFileAsync(
       'powershell.exe',
-      ['-Command', '(Get-Item $args[0]).VersionInfo.FileVersion', filePath],
+      ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
       { encoding: 'utf8', timeout: 5000 },
     );
     const version = stdout.trim();

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -65,10 +65,12 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
     // Embed the path in the -Command string: a trailing argv token does not populate $args under
     // -Command, so `(Get-Item $args[0])` reads an empty path and fails.
     const psPath = filePath.replace(/'/g, "''");
+    // 15s, not a couple: powershell cold-start under parallel CI load can exceed 5s, and a timeout
+    // kill (empty stdout) silently drops the fixed-runtime probe to the Evergreen fallback.
     const { stdout } = await execFileAsync(
       'powershell.exe',
       ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
-      { encoding: 'utf8', timeout: 5000 },
+      { encoding: 'utf8', timeout: 15000 },
     );
     // Return only the numeric prefix — FileVersion can carry trailing text (e.g. "150.0.0 (rc)").
     const match = stdout.trim().match(/^\d+\.\d+\.\d+(?:\.\d+)?/);

--- a/packages/tauri-service/src/edgeDriverManager.ts
+++ b/packages/tauri-service/src/edgeDriverManager.ts
@@ -65,12 +65,14 @@ async function readFileVersion(filePath: string): Promise<string | undefined> {
     // Embed the path in the -Command string: a trailing argv token does not populate $args under
     // -Command, so `(Get-Item $args[0])` reads an empty path and fails.
     const psPath = filePath.replace(/'/g, "''");
-    // 15s, not a couple: powershell cold-start under parallel CI load can exceed 5s, and a timeout
-    // kill (empty stdout) silently drops the fixed-runtime probe to the Evergreen fallback.
+    // Default 15s, overridable via WDIO_EDGE_PROBE_TIMEOUT_MS: a timeout kill (empty stdout) silently
+    // drops the fixed-runtime probe to the Evergreen fallback, and powershell can be starved for tens
+    // of seconds on a heavily parallel CI runner where a version read is otherwise ~1s.
+    const timeoutMs = Number(process.env.WDIO_EDGE_PROBE_TIMEOUT_MS) || 15000;
     const { stdout } = await execFileAsync(
       'powershell.exe',
       ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
-      { encoding: 'utf8', timeout: 15000 },
+      { encoding: 'utf8', timeout: timeoutMs },
     );
     // Return only the numeric prefix — FileVersion can carry trailing text (e.g. "150.0.0 (rc)").
     const match = stdout.trim().match(/^\d+\.\d+\.\d+(?:\.\d+)?/);

--- a/packages/tauri-service/src/launcher.ts
+++ b/packages/tauri-service/src/launcher.ts
@@ -281,7 +281,12 @@ export default class TauriLaunchService {
     if (process.platform === 'win32' && firstResolvedBinaryPath !== undefined) {
       const autoDownloadEdgeDriver = this.options.autoDownloadEdgeDriver ?? true;
       log.debug('Checking Edge WebDriver compatibility...');
-      const edgeDriverResult = await ensureMsEdgeDriver(firstResolvedBinaryPath, autoDownloadEdgeDriver);
+      // Read the version pin / fixed-runtime folder from the global options: msedgedriver is
+      // machine-global, so per-capability overrides don't apply to this single shared check.
+      const edgeDriverResult = await ensureMsEdgeDriver(firstResolvedBinaryPath, autoDownloadEdgeDriver, {
+        edgeDriverVersion: this.options.edgeDriverVersion,
+        env: this.options.env,
+      });
 
       if (isErr(edgeDriverResult)) {
         const errorMsg = edgeDriverResult.error.message;

--- a/packages/tauri-service/src/types.ts
+++ b/packages/tauri-service/src/types.ts
@@ -43,6 +43,14 @@ export interface TauriServiceOptions extends BaseTauriServiceOptions {
    */
   autoDownloadEdgeDriver?: boolean;
   /**
+   * Pin the exact msedgedriver version to download on Windows (e.g. `'149.0.4022.98'`), bypassing
+   * runtime detection. A CI escape hatch for the next Evergreen WebView2 drift that breaks
+   * automation. Otherwise the runtime version is auto-detected — from a fixed-version runtime folder
+   * when `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` is set, else the machine's Evergreen runtime.
+   * `EDGEDRIVER_VERSION` in the environment does the same. Windows-only.
+   */
+  edgeDriverVersion?: string;
+  /**
    * Log directory for standalone mode
    * Full path where log files should be written
    * If not specified, uses logs/standalone-{appDirName}/ in current working directory
@@ -76,6 +84,11 @@ export interface TauriServiceGlobalOptions extends BaseTauriServiceGlobalOptions
    * @default true
    */
   autoDownloadEdgeDriver?: boolean;
+  /**
+   * Pin the exact msedgedriver version to download on Windows, bypassing runtime detection
+   * (also honoured via `EDGEDRIVER_VERSION`). Windows-only. See {@link TauriServiceOptions.edgeDriverVersion}.
+   */
+  edgeDriverVersion?: string;
 }
 
 /**

--- a/packages/tauri-service/test/edgeDriverManager.spec.ts
+++ b/packages/tauri-service/test/edgeDriverManager.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { EdgeDriverResult } from '../src/edgeDriverManager.js';
+import type { EdgeDriverResult, ResolvedEdgeVersion, ResolveEdgeVersionOptions } from '../src/edgeDriverManager.js';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
@@ -26,6 +26,7 @@ vi.mock('node:fs', () => ({
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
   chmodSync: vi.fn(),
+  readdirSync: vi.fn(),
 }));
 
 describe('Edge Driver Manager', () => {
@@ -33,8 +34,14 @@ describe('Edge Driver Manager', () => {
   let detectWebView2Version: () => Promise<string | undefined>;
   let getMajorVersion: (version: string) => string;
   let findMsEdgeDriver: () => Promise<{ path?: string; version?: string }>;
-  let ensureMsEdgeDriver: (tauriBinaryPath?: string, autoDownload?: boolean) => Promise<EdgeDriverResult>;
-  let downloadMsEdgeDriver: (edgeVersion: string) => Promise<string>;
+  let ensureMsEdgeDriver: (
+    tauriBinaryPath?: string,
+    autoDownload?: boolean,
+    options?: ResolveEdgeVersionOptions,
+  ) => Promise<EdgeDriverResult>;
+  let downloadMsEdgeDriver: (edgeVersion: string, exactVersion?: boolean) => Promise<string>;
+  let detectFixedRuntimeVersion: (folder?: string) => Promise<string | undefined>;
+  let resolveTargetEdgeVersion: (options?: ResolveEdgeVersionOptions) => Promise<ResolvedEdgeVersion | undefined>;
 
   const originalPlatform = process.platform;
 
@@ -46,6 +53,8 @@ describe('Edge Driver Manager', () => {
     findMsEdgeDriver = module.findMsEdgeDriver;
     ensureMsEdgeDriver = module.ensureMsEdgeDriver;
     downloadMsEdgeDriver = module.downloadMsEdgeDriver;
+    detectFixedRuntimeVersion = module.detectFixedRuntimeVersion;
+    resolveTargetEdgeVersion = module.resolveTargetEdgeVersion;
 
     vi.clearAllMocks();
 
@@ -62,6 +71,8 @@ describe('Edge Driver Manager', () => {
       value: originalPlatform,
       configurable: true,
     });
+    delete process.env.EDGEDRIVER_VERSION;
+    delete process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER;
   });
 
   describe('getMajorVersion', () => {
@@ -289,5 +300,224 @@ describe('Edge Driver Manager', () => {
 
       await expect(downloadMsEdgeDriver('143.0.3650.139')).rejects.toThrow('Failed to download msedgedriver');
     });
+
+    it('uses the exact version (no LATEST_RELEASE remap) when exactVersion is set', async () => {
+      const { execFile } = await import('node:child_process');
+      const { existsSync, writeFileSync } = await import('node:fs');
+
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, _args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(null, 'SUCCESS', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await downloadMsEdgeDriver('149.0.4022.98', true);
+
+      const scriptContent = vi
+        .mocked(writeFileSync)
+        .mock.calls.map((call) => String(call[1]))
+        .join('\n');
+      expect(scriptContent).toContain("$driverVersion = '149.0.4022.98'");
+    });
   });
+
+  describe('detectFixedRuntimeVersion', () => {
+    it('returns undefined on non-Windows platforms', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true, configurable: true });
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBeUndefined();
+    });
+
+    it('returns undefined when no folder is given', async () => {
+      expect(await detectFixedRuntimeVersion()).toBeUndefined();
+    });
+
+    it('reads the version from msedgewebview2.exe in the folder', async () => {
+      const { existsSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
+      await mockVersionInfo('149.0.4022.98');
+
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
+    });
+
+    it('falls back to a versioned subdirectory when the runtime is nested', async () => {
+      const { existsSync, readdirSync } = await import('node:fs');
+      // Direct exe missing; a `<version>/msedgewebview2.exe` subdir exists.
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).includes('149.0.4022.98'));
+      vi.mocked(readdirSync as any).mockReturnValue(['not-a-version', '149.0.4022.98']);
+      await mockVersionInfo('149.0.4022.98');
+
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
+    });
+
+    it('returns undefined when no runtime binary is found', async () => {
+      const { existsSync, readdirSync } = await import('node:fs');
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readdirSync as any).mockReturnValue([]);
+
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBeUndefined();
+    });
+  });
+
+  describe('resolveTargetEdgeVersion', () => {
+    it('prefers an explicit edgeDriverVersion option, used verbatim', async () => {
+      expect(await resolveTargetEdgeVersion({ edgeDriverVersion: '149.0.4022.98' })).toEqual({
+        version: '149.0.4022.98',
+        source: 'override',
+      });
+    });
+
+    it('honours EDGEDRIVER_VERSION from the environment', async () => {
+      process.env.EDGEDRIVER_VERSION = '148.0.1.2';
+      expect(await resolveTargetEdgeVersion()).toEqual({ version: '148.0.1.2', source: 'override' });
+    });
+
+    it('resolves the fixed-version runtime folder from options.env', async () => {
+      const { existsSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
+      await mockVersionInfo('149.0.4022.98');
+
+      expect(
+        await resolveTargetEdgeVersion({ env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: 'C:\\FixedRuntime' } }),
+      ).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
+    });
+
+    it('reads the folder from process.env when options.env is absent', async () => {
+      process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\FixedRuntime';
+      const { existsSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
+      await mockVersionInfo('149.0.4022.98');
+
+      expect(await resolveTargetEdgeVersion()).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
+    });
+
+    it('prefers options.env folder over process.env folder', async () => {
+      process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\ProcessRuntime';
+      const { execFile } = await import('node:child_process');
+      const { existsSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        const filePath = Array.isArray(args) ? String(args[2]) : '';
+        if (filePath.includes('OptionRuntime')) callback?.(null, '149.0.4022.98\n', '');
+        else if (filePath.includes('ProcessRuntime')) callback?.(null, '130.0.0.0\n', '');
+        else callback?.(new Error('unexpected'), '', '');
+        return {} as any;
+      }) as any);
+
+      expect(
+        await resolveTargetEdgeVersion({ env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: 'C:\\OptionRuntime' } }),
+      ).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
+    });
+
+    it('falls back to the Evergreen registry version when the folder is unreadable', async () => {
+      process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\Missing';
+      const { existsSync, readdirSync } = await import('node:fs');
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readdirSync as any).mockReturnValue([]);
+      await mockExecRegistry('150.0.4000.0');
+
+      expect(await resolveTargetEdgeVersion()).toEqual({ version: '150.0.4000.0', source: 'evergreen' });
+    });
+
+    it('uses the Evergreen registry version by default', async () => {
+      await mockExecRegistry('150.0.4000.0');
+      expect(await resolveTargetEdgeVersion()).toEqual({ version: '150.0.4000.0', source: 'evergreen' });
+    });
+
+    it('returns undefined when nothing resolves', async () => {
+      const { exec } = await import('node:child_process');
+      vi.mocked(exec as any).mockImplementation(((_cmd: string, _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(new Error('not found'), '', '');
+        return {} as any;
+      }) as any);
+
+      expect(await resolveTargetEdgeVersion()).toBeUndefined();
+    });
+  });
+
+  describe('ensureMsEdgeDriver with fixed-version runtime and overrides', () => {
+    it('matches the driver to the fixed-version runtime, not the registry Evergreen', async () => {
+      const { exec, execFile } = await import('node:child_process');
+      const { existsSync } = await import('node:fs');
+
+      // Registry Evergreen 150, but the app is pinned to a 149 fixed runtime and a 150 driver is on
+      // PATH → mismatch → download for 149 (the runtime the app actually uses).
+      vi.mocked(exec as any).mockImplementation(((cmd: string, _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        if (cmd.includes('reg query') && cmd.includes('F3017226'))
+          callback?.(null, '    pv    REG_SZ    150.0.4000.0\n', '');
+        else if (cmd.includes('where msedgedriver')) callback?.(null, 'C:\\driver\\msedgedriver.exe\n', '');
+        else if (cmd.includes('--version')) callback?.(null, 'MSEdgeDriver 150.0.4000.0\n', '');
+        else callback?.(new Error('Not found'), '', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        if (Array.isArray(args) && String(args[1]).includes('VersionInfo.FileVersion'))
+          callback?.(null, '149.0.4022.98\n', '');
+        else callback?.(null, 'SUCCESS', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(existsSync).mockImplementation(
+        (p: any) => String(p).endsWith('msedgewebview2.exe') || String(p).endsWith('msedgedriver.exe'),
+      );
+
+      const result = await ensureMsEdgeDriver(undefined, true, {
+        env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: 'C:\\FixedRuntime' },
+      });
+      assert(result.ok);
+      expect(result.value.method).toBe('downloaded');
+      expect(result.value.edgeVersion).toBe('149.0.4022.98');
+    });
+
+    it('downloads the exact version for an explicit edgeDriverVersion override', async () => {
+      const { exec, execFile } = await import('node:child_process');
+      const { existsSync } = await import('node:fs');
+
+      vi.mocked(exec as any).mockImplementation(((_cmd: string, _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(new Error('not found'), '', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, _args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(null, 'SUCCESS', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = await ensureMsEdgeDriver(undefined, true, { edgeDriverVersion: '149.0.4022.98' });
+      assert(result.ok);
+      expect(result.value.method).toBe('downloaded');
+      expect(result.value.driverVersion).toBe('149.0.4022.98');
+    });
+  });
+
+  async function mockExecRegistry(pv: string) {
+    const { exec } = await import('node:child_process');
+    vi.mocked(exec as any).mockImplementation(((cmd: string, _opts: any, callback: any) => {
+      if (typeof _opts === 'function') callback = _opts;
+      if (cmd.includes('reg query') && cmd.includes('F3017226')) {
+        callback?.(null, `    pv    REG_SZ    ${pv}\n`, '');
+      } else {
+        callback?.(new Error('Not found'), '', '');
+      }
+      return {} as any;
+    }) as any);
+  }
+
+  async function mockVersionInfo(version: string) {
+    const { execFile } = await import('node:child_process');
+    vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
+      if (typeof _opts === 'function') callback = _opts;
+      if (Array.isArray(args) && String(args[1]).includes('VersionInfo.FileVersion')) {
+        callback?.(null, `${version}\n`, '');
+      } else {
+        callback?.(new Error('unexpected'), '', '');
+      }
+      return {} as any;
+    }) as any);
+  }
 });

--- a/packages/tauri-service/test/edgeDriverManager.spec.ts
+++ b/packages/tauri-service/test/edgeDriverManager.spec.ts
@@ -301,7 +301,7 @@ describe('Edge Driver Manager', () => {
       await expect(downloadMsEdgeDriver('143.0.3650.139')).rejects.toThrow('Failed to download msedgedriver');
     });
 
-    it('uses the exact version (no LATEST_RELEASE remap) when exactVersion is set', async () => {
+    it('should use the exact version (no LATEST_RELEASE remap) when exactVersion is set', async () => {
       const { execFile } = await import('node:child_process');
       const { existsSync, writeFileSync } = await import('node:fs');
 
@@ -323,16 +323,16 @@ describe('Edge Driver Manager', () => {
   });
 
   describe('detectFixedRuntimeVersion', () => {
-    it('returns undefined on non-Windows platforms', async () => {
+    it('should return undefined on non-Windows platforms', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', writable: true, configurable: true });
       expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBeUndefined();
     });
 
-    it('returns undefined when no folder is given', async () => {
+    it('should return undefined when no folder is given', async () => {
       expect(await detectFixedRuntimeVersion()).toBeUndefined();
     });
 
-    it('reads the version from msedgewebview2.exe in the folder', async () => {
+    it('should read the version from msedgewebview2.exe in the folder', async () => {
       const { existsSync } = await import('node:fs');
       vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
       await mockVersionInfo('149.0.4022.98');
@@ -340,7 +340,7 @@ describe('Edge Driver Manager', () => {
       expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
     });
 
-    it('falls back to a versioned subdirectory when the runtime is nested', async () => {
+    it('should fall back to a versioned subdirectory when the runtime is nested', async () => {
       const { existsSync, readdirSync } = await import('node:fs');
       // Direct exe missing; a `<version>/msedgewebview2.exe` subdir exists.
       vi.mocked(existsSync).mockImplementation((p: any) => String(p).includes('149.0.4022.98'));
@@ -350,7 +350,26 @@ describe('Edge Driver Manager', () => {
       expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
     });
 
-    it('returns undefined when no runtime binary is found', async () => {
+    it('should pick the highest version when multiple runtime subdirectories exist', async () => {
+      const { existsSync, readdirSync } = await import('node:fs');
+      const { execFile } = await import('node:child_process');
+      // Direct exe missing; several `<version>/msedgewebview2.exe` subdirs exist, listed out of order.
+      vi.mocked(existsSync).mockImplementation((p: any) =>
+        /[\\/]\d+\.\d+\.\d+\.\d+[\\/]msedgewebview2\.exe$/.test(String(p)),
+      );
+      vi.mocked(readdirSync as any).mockReturnValue(['149.0.4022.98', '151.0.0.0', '150.0.1.0', 'not-a-version']);
+      // Echo the version embedded in the queried exe path so we can tell which subdir was chosen.
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        const match = (Array.isArray(args) ? String(args[2]) : '').match(/(\d+\.\d+\.\d+\.\d+)/);
+        callback?.(null, `${match ? match[1] : '0.0.0.0'}\n`, '');
+        return {} as any;
+      }) as any);
+
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('151.0.0.0');
+    });
+
+    it('should return undefined when no runtime binary is found', async () => {
       const { existsSync, readdirSync } = await import('node:fs');
       vi.mocked(existsSync).mockReturnValue(false);
       vi.mocked(readdirSync as any).mockReturnValue([]);
@@ -360,19 +379,19 @@ describe('Edge Driver Manager', () => {
   });
 
   describe('resolveTargetEdgeVersion', () => {
-    it('prefers an explicit edgeDriverVersion option, used verbatim', async () => {
+    it('should prefer an explicit edgeDriverVersion option, used verbatim', async () => {
       expect(await resolveTargetEdgeVersion({ edgeDriverVersion: '149.0.4022.98' })).toEqual({
         version: '149.0.4022.98',
         source: 'override',
       });
     });
 
-    it('honours EDGEDRIVER_VERSION from the environment', async () => {
+    it('should honour EDGEDRIVER_VERSION from the environment', async () => {
       process.env.EDGEDRIVER_VERSION = '148.0.1.2';
       expect(await resolveTargetEdgeVersion()).toEqual({ version: '148.0.1.2', source: 'override' });
     });
 
-    it('resolves the fixed-version runtime folder from options.env', async () => {
+    it('should resolve the fixed-version runtime folder from options.env', async () => {
       const { existsSync } = await import('node:fs');
       vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
       await mockVersionInfo('149.0.4022.98');
@@ -382,7 +401,7 @@ describe('Edge Driver Manager', () => {
       ).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
     });
 
-    it('reads the folder from process.env when options.env is absent', async () => {
+    it('should read the folder from process.env when options.env is absent', async () => {
       process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\FixedRuntime';
       const { existsSync } = await import('node:fs');
       vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
@@ -391,7 +410,7 @@ describe('Edge Driver Manager', () => {
       expect(await resolveTargetEdgeVersion()).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
     });
 
-    it('prefers options.env folder over process.env folder', async () => {
+    it('should prefer options.env folder over process.env folder', async () => {
       process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\ProcessRuntime';
       const { execFile } = await import('node:child_process');
       const { existsSync } = await import('node:fs');
@@ -410,7 +429,7 @@ describe('Edge Driver Manager', () => {
       ).toEqual({ version: '149.0.4022.98', source: 'fixed-runtime' });
     });
 
-    it('falls back to the Evergreen registry version when the folder is unreadable', async () => {
+    it('should fall back to the Evergreen registry version when the folder is unreadable', async () => {
       process.env.WEBVIEW2_BROWSER_EXECUTABLE_FOLDER = 'C:\\Missing';
       const { existsSync, readdirSync } = await import('node:fs');
       vi.mocked(existsSync).mockReturnValue(false);
@@ -420,12 +439,12 @@ describe('Edge Driver Manager', () => {
       expect(await resolveTargetEdgeVersion()).toEqual({ version: '150.0.4000.0', source: 'evergreen' });
     });
 
-    it('uses the Evergreen registry version by default', async () => {
+    it('should use the Evergreen registry version by default', async () => {
       await mockExecRegistry('150.0.4000.0');
       expect(await resolveTargetEdgeVersion()).toEqual({ version: '150.0.4000.0', source: 'evergreen' });
     });
 
-    it('returns undefined when nothing resolves', async () => {
+    it('should return undefined when nothing resolves', async () => {
       const { exec } = await import('node:child_process');
       vi.mocked(exec as any).mockImplementation(((_cmd: string, _opts: any, callback: any) => {
         if (typeof _opts === 'function') callback = _opts;
@@ -438,7 +457,7 @@ describe('Edge Driver Manager', () => {
   });
 
   describe('ensureMsEdgeDriver with fixed-version runtime and overrides', () => {
-    it('matches the driver to the fixed-version runtime, not the registry Evergreen', async () => {
+    it('should match the driver to the fixed-version runtime, not the registry Evergreen', async () => {
       const { exec, execFile } = await import('node:child_process');
       const { existsSync } = await import('node:fs');
 
@@ -472,7 +491,7 @@ describe('Edge Driver Manager', () => {
       expect(result.value.edgeVersion).toBe('149.0.4022.98');
     });
 
-    it('downloads the exact version for an explicit edgeDriverVersion override', async () => {
+    it('should download the exact version for an explicit edgeDriverVersion override', async () => {
       const { exec, execFile } = await import('node:child_process');
       const { existsSync } = await import('node:fs');
 
@@ -491,6 +510,55 @@ describe('Edge Driver Manager', () => {
       const result = await ensureMsEdgeDriver(undefined, true, { edgeDriverVersion: '149.0.4022.98' });
       assert(result.ok);
       expect(result.value.method).toBe('downloaded');
+      expect(result.value.driverVersion).toBe('149.0.4022.98');
+    });
+
+    it('should download the exact pin even when a different same-major driver is on PATH', async () => {
+      const { exec, execFile } = await import('node:child_process');
+      const { existsSync } = await import('node:fs');
+
+      // PATH already has a 149 driver, but the pin asks for a *different* 149 build → must not reuse it.
+      vi.mocked(exec as any).mockImplementation(((cmd: string, _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        if (cmd.includes('where msedgedriver')) callback?.(null, 'C:\\driver\\msedgedriver.exe\n', '');
+        else if (cmd.includes('--version')) callback?.(null, 'MSEdgeDriver 149.0.4022.98\n', '');
+        else callback?.(new Error('Not found'), '', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, _args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(null, 'SUCCESS', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = await ensureMsEdgeDriver(undefined, true, { edgeDriverVersion: '149.0.4022.150' });
+      assert(result.ok);
+      expect(result.value.method).toBe('downloaded');
+      expect(result.value.driverVersion).toBe('149.0.4022.150');
+    });
+
+    it('should reuse an on-PATH driver that already matches the exact pin', async () => {
+      const { exec, execFile } = await import('node:child_process');
+      const { existsSync } = await import('node:fs');
+
+      vi.mocked(exec as any).mockImplementation(((cmd: string, _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        if (cmd.includes('where msedgedriver')) callback?.(null, 'C:\\driver\\msedgedriver.exe\n', '');
+        else if (cmd.includes('--version')) callback?.(null, 'MSEdgeDriver 149.0.4022.98\n', '');
+        else callback?.(new Error('Not found'), '', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(execFile as any).mockImplementation(((_cmd: string, _args: string[], _opts: any, callback: any) => {
+        if (typeof _opts === 'function') callback = _opts;
+        callback?.(null, 'SUCCESS', '');
+        return {} as any;
+      }) as any);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = await ensureMsEdgeDriver(undefined, true, { edgeDriverVersion: '149.0.4022.98' });
+      assert(result.ok);
+      expect(result.value.method).toBe('found');
       expect(result.value.driverVersion).toBe('149.0.4022.98');
     });
   });

--- a/packages/tauri-service/test/edgeDriverManager.spec.ts
+++ b/packages/tauri-service/test/edgeDriverManager.spec.ts
@@ -281,7 +281,8 @@ describe('Edge Driver Manager', () => {
       vi.mocked(existsSync).mockReturnValue(true);
 
       const result = await downloadMsEdgeDriver('143.0.3650.139');
-      expect(result).toContain('msedgedriver.exe');
+      expect(result.path).toContain('msedgedriver.exe');
+      expect(result.version).toBe('143.0.3650.139');
     });
 
     it('should throw when download fails', async () => {
@@ -340,6 +341,14 @@ describe('Edge Driver Manager', () => {
       expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
     });
 
+    it('should return only the numeric prefix when FileVersion carries trailing text', async () => {
+      const { existsSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
+      await mockVersionInfo('149.0.4022.98 (release)');
+
+      expect(await detectFixedRuntimeVersion('C:\\FixedRuntime')).toBe('149.0.4022.98');
+    });
+
     it('should fall back to a versioned subdirectory when the runtime is nested', async () => {
       const { existsSync, readdirSync } = await import('node:fs');
       // Direct exe missing; a `<version>/msedgewebview2.exe` subdir exists.
@@ -389,6 +398,14 @@ describe('Edge Driver Manager', () => {
     it('should honour EDGEDRIVER_VERSION from the environment', async () => {
       process.env.EDGEDRIVER_VERSION = '148.0.1.2';
       expect(await resolveTargetEdgeVersion()).toEqual({ version: '148.0.1.2', source: 'override' });
+    });
+
+    it('should ignore a malformed edgeDriverVersion and fall through to the registry', async () => {
+      await mockExecRegistry('150.0.4000.0');
+      expect(await resolveTargetEdgeVersion({ edgeDriverVersion: "1'; Remove-Item C:\\x" })).toEqual({
+        version: '150.0.4000.0',
+        source: 'evergreen',
+      });
     });
 
     it('should resolve the fixed-version runtime folder from options.env', async () => {

--- a/packages/tauri-service/test/edgeDriverManager.spec.ts
+++ b/packages/tauri-service/test/edgeDriverManager.spec.ts
@@ -361,7 +361,7 @@ describe('Edge Driver Manager', () => {
       // Echo the version embedded in the queried exe path so we can tell which subdir was chosen.
       vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
         if (typeof _opts === 'function') callback = _opts;
-        const match = (Array.isArray(args) ? String(args[2]) : '').match(/(\d+\.\d+\.\d+\.\d+)/);
+        const match = (Array.isArray(args) ? args.join(' ') : '').match(/(\d+\.\d+\.\d+\.\d+)/);
         callback?.(null, `${match ? match[1] : '0.0.0.0'}\n`, '');
         return {} as any;
       }) as any);
@@ -417,9 +417,9 @@ describe('Edge Driver Manager', () => {
       vi.mocked(existsSync).mockImplementation((p: any) => String(p).endsWith('msedgewebview2.exe'));
       vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
         if (typeof _opts === 'function') callback = _opts;
-        const filePath = Array.isArray(args) ? String(args[2]) : '';
-        if (filePath.includes('OptionRuntime')) callback?.(null, '149.0.4022.98\n', '');
-        else if (filePath.includes('ProcessRuntime')) callback?.(null, '130.0.0.0\n', '');
+        const command = Array.isArray(args) ? args.join(' ') : '';
+        if (command.includes('OptionRuntime')) callback?.(null, '149.0.4022.98\n', '');
+        else if (command.includes('ProcessRuntime')) callback?.(null, '130.0.0.0\n', '');
         else callback?.(new Error('unexpected'), '', '');
         return {} as any;
       }) as any);
@@ -474,7 +474,7 @@ describe('Edge Driver Manager', () => {
       }) as any);
       vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
         if (typeof _opts === 'function') callback = _opts;
-        if (Array.isArray(args) && String(args[1]).includes('VersionInfo.FileVersion'))
+        if (Array.isArray(args) && args.some((a) => String(a).includes('VersionInfo.FileVersion')))
           callback?.(null, '149.0.4022.98\n', '');
         else callback?.(null, 'SUCCESS', '');
         return {} as any;
@@ -580,7 +580,7 @@ describe('Edge Driver Manager', () => {
     const { execFile } = await import('node:child_process');
     vi.mocked(execFile as any).mockImplementation(((_cmd: string, args: string[], _opts: any, callback: any) => {
       if (typeof _opts === 'function') callback = _opts;
-      if (Array.isArray(args) && String(args[1]).includes('VersionInfo.FileVersion')) {
+      if (Array.isArray(args) && args.some((a) => String(a).includes('VersionInfo.FileVersion'))) {
         callback?.(null, `${version}\n`, '');
       } else {
         callback?.(new Error('unexpected'), '', '');

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -50,6 +50,36 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
   // Guaranteed present by the skipIf gate above; narrow once for the type-checker.
   const rt = runtime as NonNullable<typeof runtime>;
 
+  // TEMP (#539): measure the TRUE powershell FileVersion-read duration under the parallel Windows CI
+  // load (2 spawns → cold vs warm). 70s cap per spawn, 150s test timeout so vitest doesn't abort
+  // first. Remove once the duration is known.
+  it('DIAGNOSTIC: raw FileVersion read timing on this runner', async () => {
+    const { execFile } = await import('node:child_process');
+    const exe = join(rt.versionDir, RUNTIME_EXE);
+    console.error(`[PROBE-DIAG] platform=${process.platform} exe=${exe} exeExists=${existsSync(exe)}`);
+    const psPath = exe.replace(/'/g, "''");
+    for (const attempt of [1, 2]) {
+      const started = Date.now();
+      await new Promise<void>((resolve) => {
+        execFile(
+          'powershell.exe',
+          ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
+          { encoding: 'utf8', timeout: 70000 },
+          (error, stdout, stderr) => {
+            const e = error as (Error & { code?: unknown; signal?: unknown; killed?: unknown }) | null;
+            console.error(
+              `[PROBE-DIAG] attempt=${attempt} ms=${Date.now() - started} ` +
+                `error=${e ? JSON.stringify({ message: e.message, code: e.code, signal: e.signal, killed: e.killed }) : 'null'} ` +
+                `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
+            );
+            resolve();
+          },
+        );
+      });
+    }
+    expect(true).toBe(true);
+  }, 150_000);
+
   it('should read the runtime version from a folder holding msedgewebview2.exe', async () => {
     const version = await detectFixedRuntimeVersion(rt.versionDir);
     expect(version).toMatch(VERSION_PATTERN);

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   compareVersionsDesc,
   detectFixedRuntimeVersion,
@@ -50,42 +50,22 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
   // Guaranteed present by the skipIf gate above; narrow once for the type-checker.
   const rt = runtime as NonNullable<typeof runtime>;
 
-  // TEMP (#539): measure the TRUE powershell FileVersion-read duration under the parallel Windows CI
-  // load (2 spawns → cold vs warm). 70s cap per spawn, 150s test timeout so vitest doesn't abort
-  // first. Remove once the duration is known.
-  it('DIAGNOSTIC: raw FileVersion read timing on this runner', async () => {
-    const { execFile } = await import('node:child_process');
-    const exe = join(rt.versionDir, RUNTIME_EXE);
-    console.error(`[PROBE-DIAG] platform=${process.platform} exe=${exe} exeExists=${existsSync(exe)}`);
-    const psPath = exe.replace(/'/g, "''");
-    for (const attempt of [1, 2]) {
-      const started = Date.now();
-      await new Promise<void>((resolve) => {
-        execFile(
-          'powershell.exe',
-          ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
-          { encoding: 'utf8', timeout: 70000 },
-          (error, stdout, stderr) => {
-            const e = error as (Error & { code?: unknown; signal?: unknown; killed?: unknown }) | null;
-            console.error(
-              `[PROBE-DIAG] attempt=${attempt} ms=${Date.now() - started} ` +
-                `error=${e ? JSON.stringify({ message: e.message, code: e.code, signal: e.signal, killed: e.killed }) : 'null'} ` +
-                `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
-            );
-            resolve();
-          },
-        );
-      });
-    }
-    expect(true).toBe(true);
-  }, 150_000);
+  // The real powershell FileVersion read is starved to ~25-30s under the parallel Windows unit job
+  // (measured), so raise the probe timeout for this suite; production keeps its 15s default. The
+  // per-test timeouts below cover the reads (test 2 does two).
+  beforeAll(() => {
+    process.env.WDIO_EDGE_PROBE_TIMEOUT_MS = '60000';
+  });
+  afterAll(() => {
+    delete process.env.WDIO_EDGE_PROBE_TIMEOUT_MS;
+  });
 
   it('should read the runtime version from a folder holding msedgewebview2.exe', async () => {
     const version = await detectFixedRuntimeVersion(rt.versionDir);
     expect(version).toMatch(VERSION_PATTERN);
     // The install dir is named by the runtime version, so the file version shares its major.
     expect(version?.split('.')[0]).toBe(rt.version.split('.')[0]);
-  });
+  }, 120_000);
 
   it('should find the runtime via the versioned-subdirectory fallback', async () => {
     // Point at the parent Application dir → the `<version>/msedgewebview2.exe` subdir scan. The
@@ -95,7 +75,7 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
     const viaFallback = await detectFixedRuntimeVersion(rt.applicationDir);
     expect(viaFallback).toMatch(VERSION_PATTERN);
     expect(viaFallback).toBe(direct);
-  });
+  }, 120_000);
 
   it('should report source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async () => {
     const resolved = await resolveTargetEdgeVersion({
@@ -103,5 +83,5 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
     });
     expect(resolved?.source).toBe('fixed-runtime');
     expect(resolved?.version).toMatch(VERSION_PATTERN);
-  });
+  }, 120_000);
 });

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -9,7 +9,7 @@ import { detectFixedRuntimeVersion, resolveTargetEdgeVersion } from '../../src/e
  * this points the resolver at the runner's already-installed Evergreen runtime — a real folder
  * holding a real `msedgewebview2.exe` — and asserts we read its true FileVersion off disk. That is
  * the genuinely novel/risky part of the fix; the msedgedriver download + session boot are already
- * covered by the Tauri Windows E2E. Skips honestly (not passes) if no runtime is present.
+ * covered by the Tauri Windows E2E. Skips honestly if no runtime is present.
  */
 
 const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -50,6 +50,38 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
   // Guaranteed present by the skipIf gate above; narrow once for the type-checker.
   const rt = runtime as NonNullable<typeof runtime>;
 
+  // TEMP (#539): diagnose why detectFixedRuntimeVersion returns undefined on the Windows runner —
+  // captures the raw powershell FileVersion read (timing/stdout/stderr/error). Remove once known.
+  it('DIAGNOSTIC: raw FileVersion read on this runner', async () => {
+    const { execFile } = await import('node:child_process');
+    const exe = join(rt.versionDir, RUNTIME_EXE);
+    console.error(`[PROBE-DIAG] platform=${process.platform} versionDir=${rt.versionDir} exeExists=${existsSync(exe)}`);
+
+    const psPath = exe.replace(/'/g, "''");
+    const started = Date.now();
+    await new Promise<void>((resolve) => {
+      execFile(
+        'powershell.exe',
+        ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
+        { encoding: 'utf8', timeout: 5000 },
+        (error, stdout, stderr) => {
+          const e = error as (Error & { code?: unknown; signal?: unknown; killed?: unknown }) | null;
+          console.error(
+            `[PROBE-DIAG] powershell ms=${Date.now() - started} ` +
+              `error=${e ? JSON.stringify({ message: e.message, code: e.code, signal: e.signal, killed: e.killed }) : 'null'} ` +
+              `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
+          );
+          resolve();
+        },
+      );
+    });
+
+    console.error(
+      `[PROBE-DIAG] detectFixedRuntimeVersion=${JSON.stringify(await detectFixedRuntimeVersion(rt.versionDir))}`,
+    );
+    expect(true).toBe(true);
+  });
+
   it('should read the runtime version from a folder holding msedgewebview2.exe', async () => {
     const version = await detectFixedRuntimeVersion(rt.versionDir);
     expect(version).toMatch(VERSION_PATTERN);

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -50,38 +50,6 @@ describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', (
   // Guaranteed present by the skipIf gate above; narrow once for the type-checker.
   const rt = runtime as NonNullable<typeof runtime>;
 
-  // TEMP (#539): diagnose why detectFixedRuntimeVersion returns undefined on the Windows runner —
-  // captures the raw powershell FileVersion read (timing/stdout/stderr/error). Remove once known.
-  it('DIAGNOSTIC: raw FileVersion read on this runner', async () => {
-    const { execFile } = await import('node:child_process');
-    const exe = join(rt.versionDir, RUNTIME_EXE);
-    console.error(`[PROBE-DIAG] platform=${process.platform} versionDir=${rt.versionDir} exeExists=${existsSync(exe)}`);
-
-    const psPath = exe.replace(/'/g, "''");
-    const started = Date.now();
-    await new Promise<void>((resolve) => {
-      execFile(
-        'powershell.exe',
-        ['-NoProfile', '-Command', `(Get-Item -LiteralPath '${psPath}').VersionInfo.FileVersion`],
-        { encoding: 'utf8', timeout: 5000 },
-        (error, stdout, stderr) => {
-          const e = error as (Error & { code?: unknown; signal?: unknown; killed?: unknown }) | null;
-          console.error(
-            `[PROBE-DIAG] powershell ms=${Date.now() - started} ` +
-              `error=${e ? JSON.stringify({ message: e.message, code: e.code, signal: e.signal, killed: e.killed }) : 'null'} ` +
-              `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
-          );
-          resolve();
-        },
-      );
-    });
-
-    console.error(
-      `[PROBE-DIAG] detectFixedRuntimeVersion=${JSON.stringify(await detectFixedRuntimeVersion(rt.versionDir))}`,
-    );
-    expect(true).toBe(true);
-  });
-
   it('should read the runtime version from a folder holding msedgewebview2.exe', async () => {
     const version = await detectFixedRuntimeVersion(rt.versionDir);
     expect(version).toMatch(VERSION_PATTERN);

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -27,10 +27,12 @@ function findInstalledRuntime(): { versionDir: string; applicationDir: string; v
     if (!existsSync(applicationDir)) {
       continue;
     }
-    for (const entry of readdirSync(applicationDir)) {
-      if (VERSION_DIR.test(entry) && existsSync(join(applicationDir, entry, RUNTIME_EXE))) {
-        return { versionDir: join(applicationDir, entry), applicationDir, version: entry };
-      }
+    // Match the resolver: when several runtime versions coexist, the newest wins.
+    const [version] = readdirSync(applicationDir)
+      .filter((entry) => VERSION_DIR.test(entry) && existsSync(join(applicationDir, entry, RUNTIME_EXE)))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+    if (version) {
+      return { versionDir: join(applicationDir, version), applicationDir, version };
     }
   }
   return undefined;
@@ -39,7 +41,7 @@ function findInstalledRuntime(): { versionDir: string; applicationDir: string; v
 describe.skipIf(process.platform !== 'win32')('edgeDriverManager fixed-version runtime (Windows)', () => {
   const runtime = findInstalledRuntime();
 
-  it('reads the runtime version from a folder holding msedgewebview2.exe', async (ctx) => {
+  it('should read the runtime version from a folder holding msedgewebview2.exe', async (ctx) => {
     if (!runtime) {
       ctx.skip();
       return;
@@ -50,17 +52,21 @@ describe.skipIf(process.platform !== 'win32')('edgeDriverManager fixed-version r
     expect(version?.split('.')[0]).toBe(runtime.version.split('.')[0]);
   });
 
-  it('finds the runtime via the versioned-subdirectory fallback', async (ctx) => {
+  it('should find the runtime via the versioned-subdirectory fallback', async (ctx) => {
     if (!runtime) {
       ctx.skip();
       return;
     }
-    // Point at the parent Application dir → the `<version>/msedgewebview2.exe` subdir scan.
-    const version = await detectFixedRuntimeVersion(runtime.applicationDir);
-    expect(version).toMatch(VERSION_PATTERN);
+    // Point at the parent Application dir → the `<version>/msedgewebview2.exe` subdir scan. The
+    // fallback must resolve the same runtime a direct read of that subdir yields, not merely "some
+    // version-shaped string" — otherwise a scan that picked the wrong nested version would pass.
+    const direct = await detectFixedRuntimeVersion(runtime.versionDir);
+    const viaFallback = await detectFixedRuntimeVersion(runtime.applicationDir);
+    expect(viaFallback).toMatch(VERSION_PATTERN);
+    expect(viaFallback).toBe(direct);
   });
 
-  it('resolveTargetEdgeVersion reports source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async (ctx) => {
+  it('should report source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async (ctx) => {
     if (!runtime) {
       ctx.skip();
       return;

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -38,41 +38,34 @@ function findInstalledRuntime(): { versionDir: string; applicationDir: string; v
   return undefined;
 }
 
-describe.skipIf(process.platform !== 'win32')('edgeDriverManager fixed-version runtime (Windows)', () => {
-  const runtime = findInstalledRuntime();
+// Resolve once at load; the suite runs only on Windows with a real runtime present, and reports an
+// honest skip otherwise rather than a passing no-op.
+const runtime = process.platform === 'win32' ? findInstalledRuntime() : undefined;
 
-  it('should read the runtime version from a folder holding msedgewebview2.exe', async (ctx) => {
-    if (!runtime) {
-      ctx.skip();
-      return;
-    }
-    const version = await detectFixedRuntimeVersion(runtime.versionDir);
+describe.skipIf(!runtime)('edgeDriverManager fixed-version runtime (Windows)', () => {
+  // Guaranteed present by the skipIf gate above; narrow once for the type-checker.
+  const rt = runtime as NonNullable<typeof runtime>;
+
+  it('should read the runtime version from a folder holding msedgewebview2.exe', async () => {
+    const version = await detectFixedRuntimeVersion(rt.versionDir);
     expect(version).toMatch(VERSION_PATTERN);
     // The install dir is named by the runtime version, so the file version shares its major.
-    expect(version?.split('.')[0]).toBe(runtime.version.split('.')[0]);
+    expect(version?.split('.')[0]).toBe(rt.version.split('.')[0]);
   });
 
-  it('should find the runtime via the versioned-subdirectory fallback', async (ctx) => {
-    if (!runtime) {
-      ctx.skip();
-      return;
-    }
+  it('should find the runtime via the versioned-subdirectory fallback', async () => {
     // Point at the parent Application dir → the `<version>/msedgewebview2.exe` subdir scan. The
     // fallback must resolve the same runtime a direct read of that subdir yields, not merely "some
     // version-shaped string" — otherwise a scan that picked the wrong nested version would pass.
-    const direct = await detectFixedRuntimeVersion(runtime.versionDir);
-    const viaFallback = await detectFixedRuntimeVersion(runtime.applicationDir);
+    const direct = await detectFixedRuntimeVersion(rt.versionDir);
+    const viaFallback = await detectFixedRuntimeVersion(rt.applicationDir);
     expect(viaFallback).toMatch(VERSION_PATTERN);
     expect(viaFallback).toBe(direct);
   });
 
-  it('should report source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async (ctx) => {
-    if (!runtime) {
-      ctx.skip();
-      return;
-    }
+  it('should report source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async () => {
     const resolved = await resolveTargetEdgeVersion({
-      env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: runtime.versionDir },
+      env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: rt.versionDir },
     });
     expect(resolved?.source).toBe('fixed-runtime');
     expect(resolved?.version).toMatch(VERSION_PATTERN);

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -1,7 +1,11 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { detectFixedRuntimeVersion, resolveTargetEdgeVersion } from '../../src/edgeDriverManager.js';
+import {
+  compareVersionsDesc,
+  detectFixedRuntimeVersion,
+  resolveTargetEdgeVersion,
+} from '../../src/edgeDriverManager.js';
 
 /**
  * Real-Windows proof for the fixed-version WebView2 runtime path (#539). Rather than download a
@@ -27,10 +31,10 @@ function findInstalledRuntime(): { versionDir: string; applicationDir: string; v
     if (!existsSync(applicationDir)) {
       continue;
     }
-    // Match the resolver: when several runtime versions coexist, the newest wins.
+    // Reuse the resolver's own comparator so "newest wins" can't diverge from production.
     const [version] = readdirSync(applicationDir)
       .filter((entry) => VERSION_DIR.test(entry) && existsSync(join(applicationDir, entry, RUNTIME_EXE)))
-      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+      .sort(compareVersionsDesc);
     if (version) {
       return { versionDir: join(applicationDir, version), applicationDir, version };
     }

--- a/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
+++ b/packages/tauri-service/test/integration/edgeDriverManager.integration.spec.ts
@@ -1,0 +1,74 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { detectFixedRuntimeVersion, resolveTargetEdgeVersion } from '../../src/edgeDriverManager.js';
+
+/**
+ * Real-Windows proof for the fixed-version WebView2 runtime path (#539). Rather than download a
+ * fixed-version runtime (no stable versioned URL exists; only the latest two majors are published),
+ * this points the resolver at the runner's already-installed Evergreen runtime — a real folder
+ * holding a real `msedgewebview2.exe` — and asserts we read its true FileVersion off disk. That is
+ * the genuinely novel/risky part of the fix; the msedgedriver download + session boot are already
+ * covered by the Tauri Windows E2E. Skips honestly (not passes) if no runtime is present.
+ */
+
+const VERSION_DIR = /^\d+\.\d+\.\d+\.\d+$/;
+const RUNTIME_EXE = 'msedgewebview2.exe';
+const VERSION_PATTERN = /^\d+\.\d+\.\d+/;
+
+/** Locate an installed Evergreen WebView2 runtime: `<base>\Microsoft\EdgeWebView\Application\<ver>\`. */
+function findInstalledRuntime(): { versionDir: string; applicationDir: string; version: string } | undefined {
+  const bases = [process.env['ProgramFiles(x86)'], process.env.ProgramFiles, process.env.LOCALAPPDATA].filter(
+    (base): base is string => Boolean(base),
+  );
+
+  for (const base of bases) {
+    const applicationDir = join(base, 'Microsoft', 'EdgeWebView', 'Application');
+    if (!existsSync(applicationDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(applicationDir)) {
+      if (VERSION_DIR.test(entry) && existsSync(join(applicationDir, entry, RUNTIME_EXE))) {
+        return { versionDir: join(applicationDir, entry), applicationDir, version: entry };
+      }
+    }
+  }
+  return undefined;
+}
+
+describe.skipIf(process.platform !== 'win32')('edgeDriverManager fixed-version runtime (Windows)', () => {
+  const runtime = findInstalledRuntime();
+
+  it('reads the runtime version from a folder holding msedgewebview2.exe', async (ctx) => {
+    if (!runtime) {
+      ctx.skip();
+      return;
+    }
+    const version = await detectFixedRuntimeVersion(runtime.versionDir);
+    expect(version).toMatch(VERSION_PATTERN);
+    // The install dir is named by the runtime version, so the file version shares its major.
+    expect(version?.split('.')[0]).toBe(runtime.version.split('.')[0]);
+  });
+
+  it('finds the runtime via the versioned-subdirectory fallback', async (ctx) => {
+    if (!runtime) {
+      ctx.skip();
+      return;
+    }
+    // Point at the parent Application dir → the `<version>/msedgewebview2.exe` subdir scan.
+    const version = await detectFixedRuntimeVersion(runtime.applicationDir);
+    expect(version).toMatch(VERSION_PATTERN);
+  });
+
+  it('resolveTargetEdgeVersion reports source "fixed-runtime" for WEBVIEW2_BROWSER_EXECUTABLE_FOLDER', async (ctx) => {
+    if (!runtime) {
+      ctx.skip();
+      return;
+    }
+    const resolved = await resolveTargetEdgeVersion({
+      env: { WEBVIEW2_BROWSER_EXECUTABLE_FOLDER: runtime.versionDir },
+    });
+    expect(resolved?.source).toBe('fixed-runtime');
+    expect(resolved?.version).toMatch(VERSION_PATTERN);
+  });
+});


### PR DESCRIPTION
Closes #539.

## Problem

On Windows, `edgeDriverManager` downloads `msedgedriver` matched to the **registry Evergreen** WebView2 version (`detectWebView2Version()` reads the `EdgeUpdate\Clients\{F3017226…}` `pv`). When a Tauri app runs against a **fixed-version WebView2 runtime** — a supported distribution mode (`bundle.windows.webviewInstallMode: "fixedRuntime"`, or `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`) — the app's actual runtime differs from the installed Evergreen, so we fetch a mismatched driver and session creation fails:

```
session not created: This version of Microsoft Edge WebDriver only supports Microsoft Edge version 150
Current browser version is 149.0.4022.98 … tauri-e2e-app.exe
```

## Fix

Resolve the target Edge version through a precedence chain instead of always reading the registry Evergreen (`resolveTargetEdgeVersion`):

1. **Explicit override** — `edgeDriverVersion` service option, or the `EDGEDRIVER_VERSION` env var — used as the driver version verbatim (CI escape hatch / determinism).
2. **Fixed-version folder** — when `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` is set (read from `options.env` then `process.env`, mirroring the app's `{...process.env, ...options.env}`), read the FileVersion of `msedgewebview2.exe` in that folder (with a versioned-subdir fallback scan) and drive `getDriverVersionForEdge()` off that.
3. **Registry Evergreen** — unchanged default; still the canary that catches runtime regressions.

`ensureMsEdgeDriver` gains an `options` parameter and logs which source won. The launcher passes global service options (the pin + `env`) into the machine-global driver check. Fail-open behaviour is preserved: an unresolved version skips the check exactly as before. Windows-only; a no-op on macOS/Linux.

## Tests / proof

- **Unit** (`edgeDriverManager.spec.ts`, +11): override precedence, `options.env` vs `process.env` sourcing, direct + versioned-subdir folder reads, exact-pin download, fallback-to-Evergreen, non-Windows skip. Full tauri-service suite: 670 passing.
- **Windows integration** (`edgeDriverManager.integration.spec.ts`, new): runs the resolver against the runner's **real installed** `msedgewebview2.exe` off disk — exercising the genuinely novel code (PowerShell FileVersion read, `source: 'fixed-runtime'`) with zero external download. `ctx.skip()`s honestly when no runtime is present (no false-green).

### Why no dedicated fixed-runtime session-boot E2E

A full "pin an older fixed runtime, assert the app boots" E2E was scoped out deliberately: Microsoft publishes fixed-version runtime `.cab`s only for the latest two majors via non-stable, page-scraped URLs (no `LATEST_RELEASE`-style endpoint); the only versioned/stable channel is a **third-party** NuGet package; and the mismatch is runner-Evergreen-dependent, risking silent false-greens. Any CI job built on that would be flaky or a no-op. The driver download + session boot are already covered by the existing Tauri Windows E2E; this PR adds the real-binary integration test above for the new code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
