### PR TITLE
feat(electrobun): Linux support via the native WebKitGTK renderer (W3C WebDriver)

### DIFF
--- a/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
+++ b/.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
@@ -5,7 +5,7 @@ name: Build Electrobun E2E App
 # CEF. The CEF toolchain is a beta/unverified path: `electrobun build` downloads a
 # ~150MB CEF framework, so the build is slower and more network-dependent than the
 # other e2e-app builds. macOS is the only validated platform; Windows/Linux bundle
-# layout is unverified (see packages/electrobun-service RESEARCH_FINDINGS).
+# layout is unverified.
 
 permissions:
   contents: read

--- a/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
@@ -55,18 +55,19 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      # CEF + native-wrapper runtime dependencies on Linux. libwebkit2gtk-4.1-0 is
-      # required even though we use the CEF renderer: electrobun's libNativeWrapper.so
-      # links webkit2gtk (it supports both renderers), so it won't dlopen without it
-      # ("libwebkit2gtk-4.1.so.0: cannot open shared object file"). The rest are CEF's
-      # Chromium runtime libs.
-      - name: 🐧 Install CEF Runtime Dependencies (Linux)
+      # Linux drives the native WebKitGTK renderer over W3C WebDriver:
+      #  - webkit2gtk-driver provides the WebKitWebDriver binary the service spawns;
+      #  - libwebkit2gtk-4.1-0 is the renderer runtime (electrobun's libNativeWrapper.so
+      #    links webkit2gtk, so it won't dlopen without it);
+      #  - the rest are shared GTK/NSS/X runtime libs the app needs.
+      - name: 🐧 Install WebKitGTK Runtime Dependencies (Linux)
         if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             xvfb \
+            webkit2gtk-driver \
             libwebkit2gtk-4.1-0 \
             libayatana-appindicator3-1 \
             libnss3 \

--- a/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
+++ b/.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
@@ -57,8 +57,7 @@ jobs:
 
       # Linux drives the native WebKitGTK renderer over W3C WebDriver:
       #  - webkit2gtk-driver provides the WebKitWebDriver binary the service spawns;
-      #  - libwebkit2gtk-4.1-0 is the renderer runtime (electrobun's libNativeWrapper.so
-      #    links webkit2gtk, so it won't dlopen without it);
+      #  - libwebkit2gtk-4.1-0 is the renderer runtime;
       #  - the rest are shared GTK/NSS/X runtime libs the app needs.
       - name: 🐧 Install WebKitGTK Runtime Dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,8 @@ jobs:
   #
   # Linux builds the native WebKitGTK renderer (bundleCEF:false → no CEF download), driven
   # over W3C WebDriver (WebKitWebDriver) — unblocked by electrobun 2.0.1 (#467). The e2e leg
-  # is NON-GATING for now (a proof leg, like Windows started) until it's proven green; it is
-  # not yet in ci-status.needs. CEF-on-Linux stays unsupported (#320).
+  # is GATING (in ci-status.needs), proven green across 3 consecutive runs. CEF-on-Linux stays
+  # unsupported (#320).
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-macos-arm:
     name: Build Electrobun E2E App [macOS-ARM]
@@ -280,7 +280,7 @@ jobs:
       os: 'windows-latest'
 
   # Electrobun E2E app [Linux] — native WebKitGTK renderer (bundleCEF:false → no CEF
-  # download). Driven over W3C WebDriver in the e2e leg below (non-gating proof leg).
+  # download). Driven over W3C WebDriver in the (gating) e2e leg below.
   build-electrobun-e2e-app-linux:
     name: Build Electrobun E2E App [Linux]
     needs: [detect-changes]
@@ -773,8 +773,8 @@ jobs:
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E tests — macOS (CEF), single CDP-attach provider (no provider matrix).
-  # Windows (WebView2) and Linux (WebKitGTK/W3C) run as separate jobs below — Windows gating,
-  # Linux non-gating for now (electrobun 2.0.1 landed WebKitGTK automation, #467).
+  # Windows (WebView2) and Linux (WebKitGTK/W3C) run as separate jobs below — all gating
+  # (electrobun 2.0.1 landed WebKitGTK automation, #467).
   #
   # Test-type matrix: 'standard' (api/application/execute/logging/mock),
   # 'window' (two CEF views), 'deeplink' (macOS-only; auto-skips elsewhere).
@@ -982,9 +982,9 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
 
   # ────────────────────────────────────────────────────────────────────────
-  # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver). NON-GATING proof leg
-  # (not in ci-status.needs) until proven green — mirrors how the Windows WebView2 leg started.
-  # 'standard' only for now (window/multiremote follow once the single-window path is solid).
+  # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver). GATING (in
+  # ci-status.needs) — proven green across 3 consecutive runs. 'standard' only for now
+  # (window/multiremote follow once the single-window path is solid).
   # ────────────────────────────────────────────────────────────────────────
   e2e-electrobun-linux:
     name: E2E - Electrobun [Linux] - ${{ matrix.test-type }}
@@ -1252,13 +1252,12 @@ jobs:
       - e2e-dioxus-linux
       - e2e-dioxus-windows
       - e2e-dioxus-macos-arm
-      # Electrobun gates: macOS CEF `standard`, plus Windows WebView2 `standard` + `window`
-      # + `multiremote` (multi-window AND per-instance isolation work on WebView2 — no
-      # persist:default gap — so they run where CEF is local-only / single-instance). The Linux
-      # WebKitGTK/W3C leg (e2e-electrobun-linux) runs but is NON-GATING for now — omitted from
-      # this needs-list until proven green (mirrors how Windows started). deeplink stays
-      # local-only (also upstream-gated on Windows/Linux — #465).
+      # Electrobun gates: macOS CEF `standard`, Linux WebKitGTK/W3C `standard`, plus Windows
+      # WebView2 `standard` + `window` + `multiremote` (multi-window AND per-instance isolation
+      # work on WebView2 — no persist:default gap — so they run where CEF is local-only /
+      # single-instance). deeplink stays local-only (upstream-gated on Windows/Linux — #465).
       - e2e-electrobun-macos-arm
+      - e2e-electrobun-linux
       # React Native — Android emulator + iOS simulator E2E are required gates.
       - e2e-react-native-linux
       - e2e-react-native-ios-macos-old-arch
@@ -1308,6 +1307,7 @@ jobs:
       - build-dioxus-e2e-app-macos-arm
       - build-electrobun-e2e-app-macos-arm
       - build-electrobun-e2e-app-windows
+      - build-electrobun-e2e-app-linux
       - build-electrobun-package-app-macos-arm
       - build-electrobun-package-app-windows
       - build-dioxus-package-app-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,10 @@ jobs:
   # ~150MB CEF download. macOS is the validated CEF platform; Windows builds the native
   # WebView2 renderer in the sibling job below (bundleCEF:false → no CEF download).
   #
-  # Linux is NOT built/run: its CEF can't recover from the chrome-runtime persist:default
-  # profile failure (the global-context fallback serves no /json), and native WebKitGTK
-  # needs upstream W3C automation (blackboardsh/electrobun#467). Re-add a Linux leg once
-  # one of those lands (#320 CEF / #317 native).
+  # Linux builds the native WebKitGTK renderer (bundleCEF:false → no CEF download), driven
+  # over W3C WebDriver (WebKitWebDriver) — unblocked by electrobun 2.0.1 (#467). The e2e leg
+  # is NON-GATING for now (a proof leg, like Windows started) until it's proven green; it is
+  # not yet in ci-status.needs. CEF-on-Linux stays unsupported (#320).
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-macos-arm:
     name: Build Electrobun E2E App [macOS-ARM]
@@ -278,6 +278,17 @@ jobs:
     secrets: inherit
     with:
       os: 'windows-latest'
+
+  # Electrobun E2E app [Linux] — native WebKitGTK renderer (bundleCEF:false → no CEF
+  # download). Driven over W3C WebDriver in the e2e leg below (non-gating proof leg).
+  build-electrobun-e2e-app-linux:
+    name: Build Electrobun E2E App [Linux]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    uses: ./.github/workflows/_ci-build-electrobun-e2e-app.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
 
   # macOS (CEF) + Windows (WebView2). The package-test fixture build mirrors the e2e build
   # (Bun, tar artifact); Windows builds the native WebView2 renderer (no CEF download).
@@ -964,6 +975,29 @@ jobs:
     secrets: inherit
     with:
       os: 'windows-latest'
+      node-version: '24'
+      test-type: ${{ matrix.test-type }}
+      build_id: ${{ needs.build.outputs.build_id }}
+      artifact_size: ${{ needs.build.outputs.artifact_size }}
+      cache_key: ${{ needs.build.outputs.cache_key }}
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver). NON-GATING proof leg
+  # (not in ci-status.needs) until proven green — mirrors how the Windows WebView2 leg started.
+  # 'standard' only for now (window/multiremote follow once the single-window path is solid).
+  # ────────────────────────────────────────────────────────────────────────
+  e2e-electrobun-linux:
+    name: E2E - Electrobun [Linux] - ${{ matrix.test-type }}
+    needs: [detect-changes, build, build-electrobun-e2e-app-linux]
+    if: needs.detect-changes.outputs.run_electrobun == 'true' && needs.detect-changes.outputs.run_lint_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: ['standard']
+    uses: ./.github/workflows/_ci-e2e-electrobun-all-providers.reusable.yml
+    secrets: inherit
+    with:
+      os: 'ubuntu-latest'
       node-version: '24'
       test-type: ${{ matrix.test-type }}
       build_id: ${{ needs.build.outputs.build_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,12 +247,8 @@ jobs:
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E app — macOS (CEF bundle, no Rust crates). The CEF fixture build is
   # the biggest unknown in this pipeline: a beta Bun/CEF toolchain that pulls a
-  # ~150MB CEF download. macOS is the validated CEF platform; Windows builds the native
-  # WebView2 renderer in the sibling job below (bundleCEF:false → no CEF download).
-  #
-  # Linux builds the native WebKitGTK renderer (bundleCEF:false → no CEF download), driven
-  # over W3C WebDriver (WebKitWebDriver) — unblocked by electrobun 2.0.1 (#467). The e2e leg
-  # is GATING (in ci-status.needs). CEF-on-Linux stays unsupported (#320).
+  # ~150MB CEF download. macOS is the validated CEF platform; Windows and Linux build the
+  # native renderer (bundleCEF:false → no CEF download) in the sibling jobs below.
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-macos-arm:
     name: Build Electrobun E2E App [macOS-ARM]
@@ -264,10 +260,9 @@ jobs:
       os: 'macos-latest'
 
   # ────────────────────────────────────────────────────────────────────────
-  # Electrobun E2E app [Windows] — built with the native WebView2 renderer
-  # (bundleCEF:false → no CEF download). The service injects --remote-debugging-port via
-  # WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS and attaches over CDP (msedgedriver), no upstream
-  # dependency. Gating (in ci-status.needs), alongside the macOS CEF build.
+  # Electrobun E2E app [Windows] — built with the native WebView2 renderer. The service injects
+  # --remote-debugging-port via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS and attaches over CDP
+  # (msedgedriver), no upstream dependency.
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-windows:
     name: Build Electrobun E2E App [Windows]
@@ -278,8 +273,8 @@ jobs:
     with:
       os: 'windows-latest'
 
-  # Electrobun E2E app [Linux] — native WebKitGTK renderer (bundleCEF:false → no CEF
-  # download). Driven over W3C WebDriver in the (gating) e2e leg below.
+  # Electrobun E2E app [Linux] — native WebKitGTK renderer, driven over W3C WebDriver in the
+  # e2e leg below.
   build-electrobun-e2e-app-linux:
     name: Build Electrobun E2E App [Linux]
     needs: [detect-changes]
@@ -772,8 +767,7 @@ jobs:
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E tests — macOS (CEF), single CDP-attach provider (no provider matrix).
-  # Windows (WebView2) and Linux (WebKitGTK/W3C) run as separate jobs below — all gating
-  # (electrobun 2.0.1 landed WebKitGTK automation, #467).
+  # Windows (WebView2) and Linux (WebKitGTK/W3C) run as separate jobs below.
   #
   # Test-type matrix: 'standard' (api/application/execute/logging/mock),
   # 'window' (two CEF views), 'deeplink' (macOS-only; auto-skips elsewhere).
@@ -960,7 +954,7 @@ jobs:
   # Electrobun E2E [Windows] — WebView2 over CDP (msedgedriver, classic WebDriver). Runs
   # `standard`, `window` (multi-window), and `multiremote` (two isolated WebView2 instances in
   # one worker — each its own process + LOCALAPPDATA data dir) — all capabilities CEF lacks, so
-  # they run on Windows where CEF is local-only / single-instance. Gating (in ci-status.needs).
+  # they run on Windows where CEF is local-only / single-instance.
   # ────────────────────────────────────────────────────────────────────────
   e2e-electrobun-windows:
     name: E2E - Electrobun [Windows] - ${{ matrix.test-type }}
@@ -981,9 +975,7 @@ jobs:
       cache_key: ${{ needs.build.outputs.cache_key }}
 
   # ────────────────────────────────────────────────────────────────────────
-  # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver). GATING (in
-  # ci-status.needs). 'standard' only for now (window/multiremote follow once the single-window
-  # path is solid).
+  # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver).
   # ────────────────────────────────────────────────────────────────────────
   e2e-electrobun-linux:
     name: E2E - Electrobun [Linux] - ${{ matrix.test-type }}
@@ -1251,10 +1243,8 @@ jobs:
       - e2e-dioxus-linux
       - e2e-dioxus-windows
       - e2e-dioxus-macos-arm
-      # Electrobun gates: macOS CEF `standard`, Linux WebKitGTK/W3C `standard`, plus Windows
-      # WebView2 `standard` + `window` + `multiremote` (multi-window AND per-instance isolation
-      # work on WebView2 — no persist:default gap — so they run where CEF is local-only /
-      # single-instance). deeplink stays local-only (upstream-gated on Windows/Linux — #465).
+      # Electrobun gates: macOS CEF `standard`, Linux WebKitGTK/W3C `standard`, Windows WebView2
+      # `standard` + `window` + `multiremote`.
       - e2e-electrobun-macos-arm
       - e2e-electrobun-linux
       # React Native — Android emulator + iOS simulator E2E are required gates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,7 @@ jobs:
   #
   # Linux builds the native WebKitGTK renderer (bundleCEF:false → no CEF download), driven
   # over W3C WebDriver (WebKitWebDriver) — unblocked by electrobun 2.0.1 (#467). The e2e leg
-  # is GATING (in ci-status.needs), proven green across 3 consecutive runs. CEF-on-Linux stays
-  # unsupported (#320).
+  # is GATING (in ci-status.needs). CEF-on-Linux stays unsupported (#320).
   # ────────────────────────────────────────────────────────────────────────
   build-electrobun-e2e-app-macos-arm:
     name: Build Electrobun E2E App [macOS-ARM]
@@ -983,8 +982,8 @@ jobs:
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E tests — Linux (native WebKitGTK over W3C WebDriver). GATING (in
-  # ci-status.needs) — proven green across 3 consecutive runs. 'standard' only for now
-  # (window/multiremote follow once the single-window path is solid).
+  # ci-status.needs). 'standard' only for now (window/multiremote follow once the single-window
+  # path is solid).
   # ────────────────────────────────────────────────────────────────────────
   e2e-electrobun-linux:
     name: E2E - Electrobun [Linux] - ${{ matrix.test-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,8 +773,8 @@ jobs:
 
   # ────────────────────────────────────────────────────────────────────────
   # Electrobun E2E tests — macOS (CEF), single CDP-attach provider (no provider matrix).
-  # Windows (WebView2) runs as a separate gating job below; Linux is NOT run (CEF serves
-  # no /json off macOS; native WebKitGTK needs upstream blackboardsh/electrobun#467).
+  # Windows (WebView2) and Linux (WebKitGTK/W3C) run as separate jobs below — Windows gating,
+  # Linux non-gating for now (electrobun 2.0.1 landed WebKitGTK automation, #467).
   #
   # Test-type matrix: 'standard' (api/application/execute/logging/mock),
   # 'window' (two CEF views), 'deeplink' (macOS-only; auto-skips elsewhere).
@@ -1254,9 +1254,10 @@ jobs:
       - e2e-dioxus-macos-arm
       # Electrobun gates: macOS CEF `standard`, plus Windows WebView2 `standard` + `window`
       # + `multiremote` (multi-window AND per-instance isolation work on WebView2 — no
-      # persist:default gap — so they run where CEF is local-only / single-instance). Linux
-      # is not run (CEF serves no /json; native WebKitGTK needs upstream automation #467).
-      # deeplink stays local-only (also upstream-gated on Windows — #465).
+      # persist:default gap — so they run where CEF is local-only / single-instance). The Linux
+      # WebKitGTK/W3C leg (e2e-electrobun-linux) runs but is NON-GATING for now — omitted from
+      # this needs-list until proven green (mirrors how Windows started). deeplink stays
+      # local-only (also upstream-gated on Windows/Linux — #465).
       - e2e-electrobun-macos-arm
       # React Native — Android emulator + iOS simulator E2E are required gates.
       - e2e-react-native-linux

--- a/docs/design/electrobun-multi-instance-upstream-draft.md
+++ b/docs/design/electrobun-multi-instance-upstream-draft.md
@@ -7,7 +7,7 @@
 `@wdio/electrobun-service` multiremote/parallel test execution needs to run multiple
 concurrent instances of the same app. Today that requires a workaround (per-worker
 `.app` clone + `build.json` port edit + distinct `CFFIXED_USER_HOME`). A launch-time
-override would make it first-class. See RESEARCH_FINDINGS.md for the mechanism.
+override would make it first-class.
 
 ## Existing adjacent issues (searched — none covers this exact need)
 - **#445** Make CEF remote debugging opt-in — same `settings.remote_debugging_port` code path (security framing, not a runtime port override).

--- a/e2e/test/electrobun/logging.spec.ts
+++ b/e2e/test/electrobun/logging.spec.ts
@@ -16,8 +16,15 @@ function getLogDir() {
 // log when `captureBackendLogs` is set (wdio.electrobun.conf.ts). The fixture's
 // Bun backend (fixtures/e2e-apps/electrobun/src/bun/index.ts) prints '[e2e]'
 // startup lines, which the launcher tags with a '[backend]' prefix.
+// Backend log capture works on the CDP paths (macOS CEF / Windows WebView2), where the service
+// spawns the app and forwards its stdout. On Linux the WebKitGTK/W3C driver owns the app process
+// (the service never spawns it), so `captureBackendLogs` structured capture is not wired there —
+// skip these on Linux. (Live backend/frontend logs still surface via the driver's stdout; see the
+// README limitation row.)
+const describeBackend = process.platform === 'linux' ? describe.skip : describe;
+
 describe('Electrobun Log Integration', () => {
-  describe('Backend Log Capture', () => {
+  describeBackend('Backend Log Capture', () => {
     it('should capture the Bun backend stdout in the WDIO log', async () => {
       await browser.waitUntil(
         async () => {

--- a/e2e/test/electrobun/logging.spec.ts
+++ b/e2e/test/electrobun/logging.spec.ts
@@ -16,11 +16,7 @@ function getLogDir() {
 // log when `captureBackendLogs` is set (wdio.electrobun.conf.ts). The fixture's
 // Bun backend (fixtures/e2e-apps/electrobun/src/bun/index.ts) prints '[e2e]'
 // startup lines, which the launcher tags with a '[backend]' prefix.
-// Backend log capture works on the CDP paths (macOS CEF / Windows WebView2), where the service
-// spawns the app and forwards its stdout. On Linux the WebKitGTK/W3C driver owns the app process
-// (the service never spawns it), so `captureBackendLogs` structured capture is not wired there —
-// skip these on Linux. (Live backend/frontend logs still surface via the driver's stdout; see the
-// README limitation row.)
+// Skipped on Linux: the WebKitGTK/W3C driver owns the app process, so the service can't forward its stdout.
 const describeBackend = process.platform === 'linux' ? describe.skip : describe;
 
 describe('Electrobun Log Integration', () => {

--- a/e2e/test/electrobun/logging.spec.ts
+++ b/e2e/test/electrobun/logging.spec.ts
@@ -18,6 +18,10 @@ function getLogDir() {
 // startup lines, which the launcher tags with a '[backend]' prefix.
 // Skipped on Linux: the WebKitGTK/W3C driver owns the app process, so the service can't forward its stdout.
 const describeBackend = process.platform === 'linux' ? describe.skip : describe;
+// Frontend log capture on Linux/WebKitGTK is an injected console shim (no CDP console events over
+// W3C). Assert it intercepts real console.* in the live webview; the drain into the WDIO log is
+// unit-tested (webdriverEval.spec) and runs at session teardown.
+const describeFrontend = process.platform === 'linux' ? describe : describe.skip;
 
 describe('Electrobun Log Integration', () => {
   describeBackend('Backend Log Capture', () => {
@@ -37,6 +41,27 @@ describe('Electrobun Log Integration', () => {
     it('should capture the backend ready marker', async () => {
       const logs = await readWdioLogs(getLogDir());
       expect(logs).toContain('bun backend ready');
+    });
+  });
+
+  describeFrontend('Frontend Log Capture (WebKitGTK console shim)', () => {
+    it('should capture webview console.* via the injected shim', async () => {
+      const marker = `wdio-shim-${Date.now()}`;
+      await browser.electrobun.execute((_eb, m) => {
+        console.log(m, 'from-log');
+        console.warn(m, 'from-warn');
+        console.error(m, 'from-error');
+      }, marker);
+
+      type LogEntry = { level: string; args: string[] };
+      const captured = (await browser.electrobun.execute(
+        () => (globalThis as unknown as { __WDIO_ELECTROBUN_LOGS__?: LogEntry[] }).__WDIO_ELECTROBUN_LOGS__ ?? [],
+      )) as LogEntry[];
+
+      const levels = captured.filter((e) => e.args.some((a) => a.includes(marker))).map((e) => e.level);
+      expect(levels).toContain('log');
+      expect(levels).toContain('warn');
+      expect(levels).toContain('error');
     });
   });
 

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -185,10 +185,11 @@ export const config = {
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
-  // Electrobun is CDP-attach: the app binary is spawned from the worker process
-  // (no separate driver in the launcher needing a display), so the Electron
-  // headless approach applies — let @wdio/xvfb auto-manage Xvfb on Linux rather
-  // than wrapping the whole command with xvfb-run (the Wry tauri/dioxus path).
+  // autoXvfb lets @wdio/xvfb manage Xvfb for the worker process on Linux (the Electron
+  // headless approach). macOS CEF / Windows WebView2 are CDP-attach and need nothing more.
+  // The Linux WebKitGTK path spawns WebKitWebDriver from the launcher (which then launches the
+  // app) — autoXvfb does NOT cover launcher-spawned processes, so the service wraps that driver
+  // in `xvfb-run -a` itself (webkitDriver.ts), mirroring the CEF app spawn in nativeMode.ts.
   autoXvfb: true,
   services: ['electrobun'],
   framework: 'mocha',

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -138,22 +138,18 @@ const electrobunServiceOptions: ElectrobunServiceOptions = {
 };
 
 const baseCapability: ElectrobunCapability = {
-  // CDP-attach: the launcher rewrites this 'electrobun' → 'chrome' (CEF/macOS) or
-  // 'MicrosoftEdge' (WebView2/Windows) and sets the debuggerAddress onto the
-  // capability in onWorkerStart.
+  // The launcher rewrites this 'electrobun' per platform: → 'chrome' (CEF/macOS, CDP),
+  // 'MicrosoftEdge' (WebView2/Windows, CDP), or deletes it and points hostname/port at
+  // WebKitWebDriver (WebKitGTK/Linux, W3C) — all in onPrepare/onWorkerStart.
   browserName: 'electrobun',
-  // CEF (macOS) bundles Chromium 147 (147.0.7727.118); pin the driver to that major
-  // so WDIO doesn't fetch the latest (148+), which refuses to attach with "only
-  // supports Chrome version N". Matching the major is what matters (spike
-  // RESEARCH_FINDINGS §2). Bump alongside the Electrobun/CEF pin. The Windows WebView2 path
-  // omits this — the launcher pins browserVersion to the detected WebView2 *runtime* version
-  // instead, since msedgedriver must match the runtime (which can lag the Edge browser WDIO
-  // would otherwise auto-match). It also forces CLASSIC WebDriver: Edge defaults to
-  // WebDriver BiDi, whose session resets the app's only webview to about:blank (a
-  // "BiDi-CDP Mapper" target appears and the content target vanishes), so the CDP bridge
-  // finds no content. Classic attach leaves the `views://` page intact, as chromedriver
-  // does for CEF.
-  ...(process.platform === 'win32' ? { 'wdio:enforceWebDriverClassic': true } : { browserVersion: '147' }),
+  // macOS/CEF bundles a specific Chromium major; pin the driver to it so WDIO doesn't fetch a
+  // newer major that refuses to attach ("only supports Chrome version N"). Bump alongside the
+  // Electrobun/CEF pin. Windows (WebView2) and Linux (WebKitGTK) DON'T pin a browserVersion:
+  //  - Windows: the launcher pins msedgedriver to the detected WebView2 *runtime* version, and
+  //    forces CLASSIC WebDriver (Edge's default BiDi session resets the webview to about:blank).
+  //  - Linux: WebKitWebDriver is a classic W3C driver the launcher connects to directly — a
+  //    Chromium browserVersion is meaningless. Classic is forced (here + by the launcher).
+  ...(process.platform === 'darwin' ? { browserVersion: '147' } : { 'wdio:enforceWebDriverClassic': true }),
   'wdio:electrobunServiceOptions': electrobunServiceOptions,
 };
 

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -23,8 +23,8 @@ const appDir = join(__dirname, '..', 'fixtures', 'e2e-apps', 'electrobun');
  * environment subdir (dev/canary/stable) is not fixed across the beta toolchain,
  * so we glob for the first `.app` rather than hardcoding a subpath. CI can pin an
  * exact bundle via `ELECTROBUN_APP_PATH` (set after the build step) to avoid any
- * ambiguity. macOS is the only validated platform (see the service's
- * RESEARCH_FINDINGS); the Windows/Linux bundle layout is unverified.
+ * ambiguity. macOS is the only validated platform; the Windows/Linux bundle layout
+ * is unverified.
  */
 function resolveElectrobunAppPath(dir: string): string {
   const override = process.env.ELECTROBUN_APP_PATH;

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -143,11 +143,10 @@ const baseCapability: ElectrobunCapability = {
   browserName: 'electrobun',
   // macOS/CEF bundles a specific Chromium major; pin the driver to it so WDIO doesn't fetch a
   // newer major that refuses to attach ("only supports Chrome version N"). Bump alongside the
-  // Electrobun/CEF pin. Windows (WebView2) and Linux (WebKitGTK) DON'T pin a browserVersion:
-  //  - Windows: the launcher pins msedgedriver to the detected WebView2 *runtime* version, and
-  //    forces CLASSIC WebDriver (Edge's default BiDi session resets the webview to about:blank).
-  //  - Linux: WebKitWebDriver is a classic W3C driver the launcher connects to directly — a
-  //    Chromium browserVersion is meaningless. Classic is forced (here + by the launcher).
+  // Electrobun/CEF pin. Windows and Linux pin no browserVersion and force classic WebDriver:
+  //  - Windows: classic avoids Edge's default BiDi session, which resets the webview to about:blank;
+  //    the launcher pins msedgedriver to the detected WebView2 runtime version.
+  //  - Linux: WebKitWebDriver is a classic W3C driver with no Chromium version to pin.
   ...(process.platform === 'darwin' ? { browserVersion: '147' } : { 'wdio:enforceWebDriverClassic': true }),
   'wdio:electrobunServiceOptions': electrobunServiceOptions,
 };
@@ -182,17 +181,14 @@ export const config = {
   specFileRetriesDeferred: false,
   baseUrl: '',
   waitforTimeout: 10000,
-  // On Linux/WebKitGTK a New Session (which launches the app under the driver) very
-  // occasionally hangs the full timeout before attaching (~1 in 6 specs). Fail that fast (45s —
-  // a healthy New Session is a few seconds) so the spec-file retry re-spawns a fresh app rather
-  // than burning the full 120s per attempt. macOS/Windows (CDP-attach) keep 120s.
+  // On Linux/WebKitGTK a New Session occasionally hangs the full timeout before attaching
+  // (~1 in 6 specs). Fail fast at 45s (a healthy New Session takes a few seconds) so the spec-file
+  // retry re-spawns a fresh app instead of burning ~120s per attempt.
   connectionRetryTimeout: process.platform === 'linux' ? 45_000 : 120_000,
   connectionRetryCount: 3,
-  // autoXvfb lets @wdio/xvfb manage Xvfb for the worker process on Linux (the Electron
-  // headless approach). macOS CEF / Windows WebView2 are CDP-attach and need nothing more.
-  // The Linux WebKitGTK path spawns WebKitWebDriver from the launcher (which then launches the
-  // app) — autoXvfb does NOT cover launcher-spawned processes, so the service wraps that driver
-  // in `xvfb-run -a` itself (webkitDriver.ts), mirroring the CEF app spawn in nativeMode.ts.
+  // autoXvfb lets @wdio/xvfb run Xvfb for the worker process on Linux. The Linux WebKitGTK path
+  // also spawns WebKitWebDriver from the launcher, which autoXvfb does NOT cover, so the service
+  // wraps that driver in `xvfb-run -a` itself (webkitDriver.ts).
   autoXvfb: true,
   services: ['electrobun'],
   framework: 'mocha',

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -138,9 +138,8 @@ const electrobunServiceOptions: ElectrobunServiceOptions = {
 };
 
 const baseCapability: ElectrobunCapability = {
-  // The launcher rewrites this 'electrobun' per platform: → 'chrome' (CEF/macOS, CDP),
-  // 'MicrosoftEdge' (WebView2/Windows, CDP), or deletes it and points hostname/port at
-  // WebKitWebDriver (WebKitGTK/Linux, W3C) — all in onPrepare/onWorkerStart.
+  // 'electrobun' is a placeholder the launcher rewrites per platform (chrome / MicrosoftEdge, or
+  // deleted for the WebKitGTK/W3C path).
   browserName: 'electrobun',
   // macOS/CEF bundles a specific Chromium major; pin the driver to it so WDIO doesn't fetch a
   // newer major that refuses to attach ("only supports Chrome version N"). Bump alongside the

--- a/e2e/wdio.electrobun.conf.ts
+++ b/e2e/wdio.electrobun.conf.ts
@@ -183,7 +183,11 @@ export const config = {
   specFileRetriesDeferred: false,
   baseUrl: '',
   waitforTimeout: 10000,
-  connectionRetryTimeout: 120000,
+  // On Linux/WebKitGTK a New Session (which launches the app under the driver) very
+  // occasionally hangs the full timeout before attaching (~1 in 6 specs). Fail that fast (45s —
+  // a healthy New Session is a few seconds) so the spec-file retry re-spawns a fresh app rather
+  // than burning the full 120s per attempt. macOS/Windows (CDP-attach) keep 120s.
+  connectionRetryTimeout: process.platform === 'linux' ? 45_000 : 120_000,
   connectionRetryCount: 3,
   // autoXvfb lets @wdio/xvfb manage Xvfb for the worker process on Linux (the Electron
   // headless approach). macOS CEF / Windows WebView2 are CDP-attach and need nothing more.

--- a/fixtures/e2e-apps/electrobun/electrobun.config.ts
+++ b/fixtures/e2e-apps/electrobun/electrobun.config.ts
@@ -1,10 +1,10 @@
 import type { ElectrobunConfig } from 'electrobun';
 
-// macOS + Linux build with CEF — the renderer that exposes a CDP endpoint there; the
-// service pins the remote-debugging port into the built bundle's build.json at launch.
-// Windows builds with the native WebView2 (Chromium) renderer instead: it serves CDP via
-// --remote-debugging-port, which the service injects through the
-// WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS env var — no CEF (CEF-on-Windows serves no /json).
+// macOS builds with CEF — the renderer that exposes a CDP endpoint there; the service pins
+// the remote-debugging port into the built bundle's build.json at launch. Windows and Linux
+// build with the native renderer: Windows = WebView2 (Chromium) over CDP (the service injects
+// --remote-debugging-port via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS); Linux = WebKitGTK over
+// W3C WebDriver (WebKitWebDriver, electrobun >= 2.0.1). No CEF off macOS — it serves no /json.
 const bundleCEF = true;
 
 export default {
@@ -43,8 +43,11 @@ export default {
       defaultRenderer: 'native',
     },
     linux: {
-      bundleCEF,
-      defaultRenderer: 'cef',
+      // Native WebKitGTK renderer — driven over W3C WebDriver (WebKitWebDriver) by
+      // @wdio/electrobun-service once the app opts into automation (electrobun 2.0.1, #467).
+      // No CEF on Linux (it serves no /json).
+      bundleCEF: false,
+      defaultRenderer: 'native',
     },
   },
 } satisfies ElectrobunConfig;

--- a/fixtures/e2e-apps/electrobun/electrobun.config.ts
+++ b/fixtures/e2e-apps/electrobun/electrobun.config.ts
@@ -17,7 +17,7 @@ export default {
       entrypoint: 'src/bun/index.ts',
     },
     // Two views drive the multi-window surface (switchWindow / listWindows): the
-    // main counter window plus a second window with its own CEF page target.
+    // main counter window plus a second window with its own page target.
     views: {
       mainview: {
         entrypoint: 'src/mainview/index.ts',

--- a/fixtures/e2e-apps/electrobun/electrobun.config.ts
+++ b/fixtures/e2e-apps/electrobun/electrobun.config.ts
@@ -1,10 +1,8 @@
 import type { ElectrobunConfig } from 'electrobun';
 
-// macOS builds with CEF — the renderer that exposes a CDP endpoint there; the service pins
-// the remote-debugging port into the built bundle's build.json at launch. Windows and Linux
-// build with the native renderer: Windows = WebView2 (Chromium) over CDP (the service injects
-// --remote-debugging-port via WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS); Linux = WebKitGTK over
-// W3C WebDriver (WebKitWebDriver, electrobun >= 2.0.1). No CEF off macOS — it serves no /json.
+// macOS builds with CEF (the only renderer that exposes a CDP endpoint there); Windows and Linux
+// build with the native renderer — WebView2 (Chromium) over CDP on Windows, WebKitGTK over W3C
+// WebDriver on Linux. No CEF off macOS: it serves no /json.
 const bundleCEF = true;
 
 export default {
@@ -37,15 +35,10 @@ export default {
       defaultRenderer: 'cef',
     },
     win: {
-      // Native WebView2 (Chromium) renderer — driven over CDP by @wdio/electrobun-service
-      // via an injected --remote-debugging-port. No CEF bundle on Windows.
       bundleCEF: false,
       defaultRenderer: 'native',
     },
     linux: {
-      // Native WebKitGTK renderer — driven over W3C WebDriver (WebKitWebDriver) by
-      // @wdio/electrobun-service once the app opts into automation (electrobun 2.0.1, #467).
-      // No CEF on Linux (it serves no /json).
       bundleCEF: false,
       defaultRenderer: 'native',
     },

--- a/fixtures/e2e-apps/electrobun/package.json
+++ b/fixtures/e2e-apps/electrobun/package.json
@@ -9,7 +9,7 @@
     "start": "electrobun run"
   },
   "dependencies": {
-    "electrobun": "1.18.1"
+    "electrobun": "2.0.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/fixtures/e2e-apps/electrobun/src/bun/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/bun/index.ts
@@ -50,8 +50,7 @@ if (isWindows) {
 }
 // Linux (WebKitGTK/W3C): single window on purpose. The automation session attaches to the
 // primary app view; a second BrowserWindow can race the `create-web-view` handshake under CI
-// load (New Session timeouts). The 'standard' suite is single-window — Linux multi-window is
-// gated off for now (see the service README).
+// load (New Session timeouts).
 
 // Deeplink handler — `open wdio-electrobun://<path>` (macOS), routed via the
 // urlSchemes entry in electrobun.config.ts. Surface the URL into the main view

--- a/fixtures/e2e-apps/electrobun/src/bun/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/bun/index.ts
@@ -1,23 +1,23 @@
 import { app, BrowserWindow } from 'electrobun/bun';
 
-// Bun (main-process) backend for the Electrobun E2E fixture. The renderer follows the
-// per-OS electrobun.config.ts default (CEF on macOS/Linux, native WebView2 on Windows),
-// so no per-window `renderer` is set here.
+// Bun (main-process) backend for the Electrobun E2E fixture. The renderer follows the per-OS
+// electrobun.config.ts default (CEF on macOS, native WebView2 on Windows, native WebKitGTK on
+// Linux), so no per-window `renderer` is set here.
 //
-// macOS/Linux (CEF): open TWO windows, STAGGERED — the second only after the main view's
-// DOM is ready. Two are needed so the CDP bridge can enumerate a 'window-1' target: a lone
-// CEF window doesn't reliably expose a `/json` page target after the forced `persist:default`
-// partition falls back to the shared global context (an upstream gap, see #320).
-// Opening both concurrently races that fallback — a browser can spawn a
-// separate top-level window instead of embedding via SetAsChild, leaving mainview's DOM
-// unpainted ("#app-title never rendered" → flaky). Staggering lets mainview embed + paint
-// cleanly first. The bridge labels content targets in registration order: first = 'main'
-// (mainview), next = 'window-1' (secondview).
+// macOS (CEF): open TWO windows, STAGGERED — the second only after the main view's DOM is ready.
+// Two are needed so the CDP bridge can enumerate a 'window-1' target: a lone CEF window doesn't
+// reliably expose a `/json` page target after the forced `persist:default` partition falls back
+// to the shared global context (an upstream gap, see #320). Opening both concurrently races that
+// fallback — a browser can spawn a separate top-level window instead of embedding via SetAsChild,
+// leaving mainview's DOM unpainted ("#app-title never rendered" → flaky). Staggering lets mainview
+// embed + paint cleanly first. The bridge labels content targets in registration order: first =
+// 'main' (mainview), next = 'window-1' (secondview).
 //
-// Windows (WebView2): no persist:default race, so the second window opens immediately
-// (concurrently) rather than staggered behind dom-ready.
+// Windows (WebView2): no persist:default race, so the second window opens immediately.
+// Linux (WebKitGTK/W3C): SINGLE window — see the note at the window logic below.
 
 const isWindows = process.platform === 'win32';
+const isMac = process.platform === 'darwin';
 
 const mainWindow = new BrowserWindow({
   title: 'WDIO Electrobun E2E — Main',
@@ -37,8 +37,8 @@ const openSecondWindow = (): void => {
 
 if (isWindows) {
   openSecondWindow();
-} else {
-  // CEF: stagger the second window behind mainview's dom-ready (see the note above).
+} else if (isMac) {
+  // macOS CEF: stagger the second window behind mainview's dom-ready (see the note above).
   let secondOpened = false;
   mainWindow.webview.on('dom-ready', () => {
     if (secondOpened) {
@@ -48,6 +48,10 @@ if (isWindows) {
     openSecondWindow();
   });
 }
+// Linux (WebKitGTK/W3C): single window on purpose. The automation session attaches to the
+// primary app view; a second BrowserWindow can race the `create-web-view` handshake under CI
+// load (New Session timeouts). The 'standard' suite is single-window — Linux multi-window is
+// gated off for now (see the service README).
 
 // Deeplink handler — `open wdio-electrobun://<path>` (macOS), routed via the
 // urlSchemes entry in electrobun.config.ts. Surface the URL into the main view

--- a/fixtures/e2e-apps/electrobun/src/bun/index.ts
+++ b/fixtures/e2e-apps/electrobun/src/bun/index.ts
@@ -1,8 +1,7 @@
 import { app, BrowserWindow } from 'electrobun/bun';
 
-// Bun (main-process) backend for the Electrobun E2E fixture. The renderer follows the per-OS
-// electrobun.config.ts default (CEF on macOS, native WebView2 on Windows, native WebKitGTK on
-// Linux), so no per-window `renderer` is set here.
+// Bun backend for the Electrobun E2E fixture. The renderer follows the per-OS
+// electrobun.config.ts default, so no per-window `renderer` is set here.
 //
 // macOS (CEF): open TWO windows, STAGGERED — the second only after the main view's DOM is ready.
 // Two are needed so the CDP bridge can enumerate a 'window-1' target: a lone CEF window doesn't

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,7 +7,7 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2) + Linux (WebKitGTK).**
+> **Status: `0.x.y`, pre-1.0 — macOS (CEF) + Windows (native WebView2) + Linux (WebKitGTK).**
 > Windows uses the native WebView2 (Chromium) renderer over CDP — no CEF — and runs multi-window
 > + multiremote. **Linux** drives the native WebKitGTK renderer over W3C WebDriver (electrobun ≥
 > 2.0.1; gated in CI); it needs `webkit2gtk-driver` installed and is single-window. This is still

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,11 +7,11 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2), Linux (WebKitGTK)
-> experimental.** Windows uses the native WebView2 (Chromium) renderer over CDP — no CEF — and
-> runs multi-window + multiremote. **Linux** drives the native WebKitGTK renderer over W3C
-> WebDriver (electrobun ≥ 2.0.1); it needs `webkit2gtk-driver` installed. This is still a `0.x`
-> release because the **macOS CEF** path has multiremote/deeplink blocked by an upstream
+> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2) + Linux (WebKitGTK).**
+> Windows uses the native WebView2 (Chromium) renderer over CDP — no CEF — and runs multi-window
+> + multiremote. **Linux** drives the native WebKitGTK renderer over W3C WebDriver (electrobun ≥
+> 2.0.1; gated in CI); it needs `webkit2gtk-driver` installed and is single-window. This is still
+> a `0.x` release because the **macOS CEF** path has multiremote/deeplink blocked by an upstream
 > limitation. See [Known limitations](#known-limitations). `1.0` is reserved for full parity
 > once those gaps are filled ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
 > [#320](https://github.com/webdriverio/desktop-mobile/issues/320) track the work).
@@ -36,7 +36,7 @@ Build each OS with its drivable renderer:
 | **macOS** | WKWebView (native) | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
 | **Windows** | WebView2 (native, Chromium) | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
 | **Windows** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
-| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | 🧪 experimental (electrobun ≥ 2.0.1) — needs `webkit2gtk-driver` installed |
+| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported (electrobun ≥ 2.0.1) — needs `webkit2gtk-driver` installed; single-window |
 | **Linux** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
 
 ```ts
@@ -126,7 +126,7 @@ non-CEF (native-renderer) track is
 | Area | Status |
 |---|---|
 | **Windows** | ✅ supported via the native **WebView2** (Chromium) renderer over CDP — no CEF (build `bundleCEF: false` / `defaultRenderer: 'native'`, the Electrobun default). |
-| **Linux** | 🧪 experimental — the native **WebKitGTK** renderer over W3C WebDriver (`WebKitWebDriver`, electrobun ≥ 2.0.1). Build `bundleCEF: false` / `defaultRenderer: 'native'`; install `webkit2gtk-driver`. A CEF build on Linux is unsupported (serves no `/json`). |
+| **Linux** | ✅ supported via the native **WebKitGTK** renderer over W3C WebDriver (`WebKitWebDriver`, electrobun ≥ 2.0.1; gated in CI). Build `bundleCEF: false` / `defaultRenderer: 'native'`; install `webkit2gtk-driver`. Single-window (`switchWindow`/`listWindows` are best-effort). A CEF build on Linux is unsupported (serves no `/json`). |
 | multiremote / parallel workers | ✅ Windows (WebView2 isolates each instance — its own process + `LOCALAPPDATA` data dir); ✅ Linux parallel workers (each gets its own `WebKitWebDriver` + app); ❌ macOS CEF (shared `root_cache_path` → instance folding). Linux multiremote (multiple instances per worker) not yet wired. |
 | `switchWindow` / `listWindows` (multi-window) | ✅ on Windows (WebView2, gated in CI); ⚠️ macOS CEF unreliable (2-window global-context race — run locally); ⚠️ Linux best-effort (W3C window handles, mapped by order). |
 | `triggerDeeplink` | ⚠️ macOS — unreliable (no open-url routing to the spawned instance); ❌ Windows/Linux — upstream-blocked: Electrobun registers URL schemes + wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,7 +7,7 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.x.y`, pre-1.0 — macOS (CEF), Windows (native WebView2), and Linux (WebKitGTK).**
+> **Status: `0.x.y`, pre-1.0 — macOS (CEF), Windows (WebView2), and Linux (WebKitGTK).**
 > See [Automation coverage](#automation-coverage-os--renderer) for the per-OS matrix. It's still a
 > `0.x` release because the **macOS CEF** path has multiremote and deeplink blocked upstream; `1.0`
 > is reserved for full parity once those gaps are filled
@@ -33,16 +33,16 @@ directly. Build each OS with its drivable renderer:
 |---|---|---|---|---|
 | **macOS** | CEF | CDP | Chromedriver attach | ✅ supported — recommended macOS path |
 | **macOS** | WKWebView | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
-| **Windows** | WebView2 | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
+| **Windows** | WebView2 | CDP | msedgedriver attach | ✅ supported — multi-window + multiremote |
 | **Windows** | CEF | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
-| **Linux** | WebKitGTK | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported — single-window ([requirements](#linux-webkitgtk-requirements)) |
+| **Linux** | WebKitGTK | W3C WebDriver | `WebKitWebDriver` | ✅ supported — single-window ([requirements](#linux-webkitgtk-requirements)) |
 | **Linux** | CEF | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
 
 ```ts
 // electrobun.config.ts — build each OS with its drivable renderer
 export default {
   build: {
-    mac: { bundleCEF: true, defaultRenderer: 'cef' }, // WKWebView can't be driven → CEF (CDP)
+    mac: { bundleCEF: true, defaultRenderer: 'cef' }, // WKWebView can't be driven → use CEF over CDP
     win: { bundleCEF: false, defaultRenderer: 'native' }, // WebView2 over CDP
     linux: { bundleCEF: false, defaultRenderer: 'native' }, // WebKitGTK over W3C WebDriver
   },
@@ -120,10 +120,10 @@ tracked in [#320](https://github.com/webdriverio/desktop-mobile/issues/320); the
 
 | Area | Status |
 |---|---|
-| multiremote / parallel workers | ✅ Windows (WebView2 isolates each instance — its own process + `LOCALAPPDATA` data dir); ✅ Linux parallel workers (each gets its own `WebKitWebDriver` + app); ❌ macOS CEF (shared `root_cache_path` → instance folding). Linux multiremote (multiple instances per worker) not yet wired. |
-| `switchWindow` / `listWindows` (multi-window) | ✅ on Windows (WebView2, gated in CI); ⚠️ macOS CEF unreliable (2-window global-context race — run locally); ⚠️ Linux best-effort (W3C window handles, mapped by order). |
-| `triggerDeeplink` | ⚠️ macOS — unreliable (no open-url routing to the spawned instance); ❌ Windows/Linux — upstream-blocked: Electrobun registers URL schemes + wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
-| single-window apps | ⚠️ a lone CEF window doesn't reliably appear in `/json`, so the bridge can intermittently find no target to attach to. Opening a second window stabilises target exposure (the test fixtures do this, staggered behind the first window's `dom-ready`). |
+| multiremote / parallel workers | ✅ Windows — WebView2 isolates each instance, so parallel workers and multiremote both work; ✅ Linux parallel workers, each with its own `WebKitWebDriver` + app; ⚠️ Linux multiremote (multiple instances per worker) not yet wired; ❌ macOS CEF — instances fold together, per the root cause above. |
+| `switchWindow` / `listWindows` | ✅ Windows; ⚠️ macOS CEF unreliable — a 2-window global-context race, so run locally; ⚠️ Linux best-effort — W3C window handles mapped by order. |
+| `triggerDeeplink` | ⚠️ macOS unreliable — no open-url routing to the spawned instance; ❌ Windows/Linux upstream-blocked — Electrobun registers URL schemes and wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
+| single-window apps | ⚠️ a lone CEF window doesn't reliably appear in `/json`, so the bridge can intermittently find no target to attach to. Opening a second window stabilises target exposure — the fixtures open it staggered behind the first window's `dom-ready`. |
 | `emitEvent` | deferred — the Bun event bus isn't CDP-reachable. |
 
 As each upstream fix lands, the corresponding platform/feature is re-enabled and

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -57,13 +57,13 @@ on Windows/Linux where it serves no `/json`).
 ### Linux (WebKitGTK) requirements
 
 The Linux path drives the native WebKitGTK renderer over **W3C WebDriver** via
-**`WebKitWebDriver`**, which the service spawns to launch and drive the app. Install it from
-the `webkit2gtk-driver` package:
+**`WebKitWebDriver`**, which the service spawns under `xvfb-run` to launch and drive the app on
+headless machines. Install both the WebKitGTK driver and Xvfb:
 
 ```sh
-sudo apt-get install webkit2gtk-driver   # Debian/Ubuntu
-# dnf install webkit2gtk-driver           # Fedora
-# pacman -S webkit2gtk-driver             # Arch
+sudo apt-get install webkit2gtk-driver xvfb            # Debian/Ubuntu
+# dnf install webkit2gtk-driver xorg-x11-server-Xvfb   # Fedora
+# pacman -S webkit2gtk-driver xorg-server-xvfb         # Arch
 ```
 
 It requires **electrobun ≥ 2.0.1**, which exposes WebKitGTK automation upstream

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,13 +7,13 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2).** Windows uses the
-> native WebView2 (Chromium) renderer over CDP — no CEF — and runs multi-window + multiremote.
-> This is still a `0.x` release because **Linux** isn't yet drivable (CEF serves no `/json` off
-> macOS; the native WebKitGTK renderer needs upstream automation support), and on the **macOS
-> CEF** path multiremote/deeplink remain blocked by an upstream limitation. See
-> [Known limitations](#known-limitations). `1.0` is reserved for full parity once those gaps are
-> filled ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
+> **Status: `0.1.0`, pre-1.0 — macOS (CEF) + Windows (native WebView2), Linux (WebKitGTK)
+> experimental.** Windows uses the native WebView2 (Chromium) renderer over CDP — no CEF — and
+> runs multi-window + multiremote. **Linux** drives the native WebKitGTK renderer over W3C
+> WebDriver (electrobun ≥ 2.0.1); it needs `webkit2gtk-driver` installed. This is still a `0.x`
+> release because the **macOS CEF** path has multiremote/deeplink blocked by an upstream
+> limitation. See [Known limitations](#known-limitations). `1.0` is reserved for full parity
+> once those gaps are filled ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
 > [#320](https://github.com/webdriverio/desktop-mobile/issues/320) track the work).
 
 ## Installation
@@ -22,37 +22,53 @@ Vitest-style mocking, log capture, browser mode, and standalone sessions.
 npm install --save-dev @wdio/electrobun-service
 ```
 
-## Platform requirement: the CEF renderer
+## Automation coverage (OS × renderer)
 
-This is a **CDP-attach** service — it drives the app through the Chrome DevTools
-Protocol (the launcher spawns the app binary and WebdriverIO attaches via
-Chromedriver's `debuggerAddress`). Electrobun's default webview engine differs
-per platform and only the Chromium-based ones speak CDP:
+The service drives each platform through whatever automation surface its renderer exposes:
+**CDP** for the Chromium renderers (macOS CEF, Windows WebView2 — the launcher spawns the app
+and a Chromedriver attaches via `debuggerAddress`), and **W3C WebDriver** for Linux's native
+WebKitGTK renderer (`WebKitWebDriver` launches the app and the worker drives it directly).
+Build each OS with its drivable renderer:
 
-| Platform | Native webview | CDP? | How the service drives it |
-|---|---|---|---|
-| Windows | WebView2 (Chromium) | ✅ | the **native WebView2** renderer directly (no CEF) |
-| macOS | WKWebView (WebKit) | ❌ | build with the **CEF** renderer (bundled Chromium) |
-| Linux | WebKitGTK (WebKit) | ❌ | unsupported (CEF serves no `/json`; WebKitGTK automation is upstream-blocked) |
-
-So the renderer the app must be built with is **per platform** — CEF on macOS, the native
-WebView2 on Windows:
+| OS | Renderer | Automation surface | Transport | Status |
+|---|---|---|---|---|
+| **macOS** | CEF (bundled Chromium) | CDP | Chromedriver attach | ✅ supported — recommended macOS path |
+| **macOS** | WKWebView (native) | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
+| **Windows** | WebView2 (native, Chromium) | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
+| **Windows** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
+| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | 🧪 experimental (electrobun ≥ 2.0.1) — needs `webkit2gtk-driver` installed |
+| **Linux** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
 
 ```ts
-// electrobun.config.ts
+// electrobun.config.ts — build each OS with its drivable renderer
 export default {
   build: {
-    // macOS: WKWebView can't be driven, so build with CEF.
-    mac: { bundleCEF: true, defaultRenderer: 'cef' },
-    // Windows: the native WebView2 renderer speaks CDP directly — no CEF (this is the default).
-    win: { bundleCEF: false, defaultRenderer: 'native' },
+    mac: { bundleCEF: true, defaultRenderer: 'cef' }, // WKWebView can't be driven → CEF (CDP)
+    win: { bundleCEF: false, defaultRenderer: 'native' }, // WebView2 (Chromium) over CDP
+    linux: { bundleCEF: false, defaultRenderer: 'native' }, // WebKitGTK over W3C WebDriver
   },
 };
 ```
 
-On **macOS**, an app built with the default WKWebView renderer is an explicit, documented
-unsupported configuration — the launcher fails fast with a clear error. On **Windows**, a CEF
-build is likewise unsupported (CEF can't create its profile there); use the native renderer.
+A build with the **wrong renderer for its OS** is an explicit, documented unsupported
+configuration — the launcher fails fast with a clear error (WKWebView on macOS, or a CEF build
+on Windows/Linux where it serves no `/json`).
+
+### Linux (WebKitGTK) requirements
+
+The Linux path drives the native WebKitGTK renderer over **W3C WebDriver** via
+**`WebKitWebDriver`**, which the service spawns to launch and drive the app. Install it from
+the `webkit2gtk-driver` package:
+
+```sh
+sudo apt-get install webkit2gtk-driver   # Debian/Ubuntu
+# dnf install webkit2gtk-driver           # Fedora
+# pacman -S webkit2gtk-driver             # Arch
+```
+
+It requires **electrobun ≥ 2.0.1**, which exposes WebKitGTK automation upstream
+([blackboardsh/electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)). No CDP
+bridge is used on Linux — `browser.electrobun.execute` and mocking run over the W3C session.
 
 ## Quick start
 
@@ -83,13 +99,13 @@ const title = await browser.electrobun.execute(() => document.title);
 expect(title).toBe('My App');
 ```
 
-## Supported surface (macOS + Windows)
+## Supported surface (macOS + Windows + Linux)
 
 | Feature | Status |
 |---|---|
 | `execute` | ✅ |
 | mocking (`mock` + `clear`/`reset`/`restoreAllMocks` + `isMockFunction`) | ✅ |
-| frontend + backend log capture | ✅ |
+| frontend + backend log capture | ✅ (Linux: frontend via an injected console shim + the driver's stdout; `captureBackendLogs` structured capture is CDP-only) |
 | browser mode (`mode: 'browser'` against a dev server) | ✅ |
 | standalone / session mode | ✅ |
 
@@ -98,22 +114,22 @@ Browser mode also supports the optional **`devServer`** service option — the l
 ## Known limitations
 
 Most of these are **upstream Electrobun/CEF limitations**, not service bugs — the
-service code implements the full surface and is unit-tested. CEF's chrome-runtime
-can't create the `persist:default` profile its `BrowserWindow` forces and falls back
-to a global browser context; macOS recovers (serves `/json`), Linux does not.
-**Windows is driven instead via the native WebView2 (Chromium) renderer over CDP — no
-CEF.** The upstream CEF fixes and what each unblocks are tracked in
-[#320](https://github.com/webdriverio/desktop-mobile/issues/320); the non-CEF
-(native-renderer) track is
+service code implements the full surface and is unit-tested. On **macOS**, CEF's
+chrome-runtime can't create the `persist:default` profile its `BrowserWindow` forces and
+falls back to a global browser context (macOS recovers and serves `/json`; a CEF build off
+macOS does not — so **Windows** uses the native WebView2 renderer over CDP and **Linux** uses
+the native WebKitGTK renderer over W3C WebDriver instead). The upstream CEF fixes and what each
+unblocks are tracked in [#320](https://github.com/webdriverio/desktop-mobile/issues/320); the
+non-CEF (native-renderer) track is
 [#317](https://github.com/webdriverio/desktop-mobile/issues/317).
 
 | Area | Status |
 |---|---|
 | **Windows** | ✅ supported via the native **WebView2** (Chromium) renderer over CDP — no CEF (build `bundleCEF: false` / `defaultRenderer: 'native'`, the Electrobun default). |
-| **Linux** | ❌ unsupported — CEF serves no `/json`, and the native WebKitGTK renderer needs upstream WebDriver-automation support ([#317](https://github.com/webdriverio/desktop-mobile/issues/317)). The launcher throws a clear `SevereServiceError` in native mode. |
-| multiremote / parallel workers | ✅ Windows (WebView2 isolates each instance — its own process + `LOCALAPPDATA` data dir); ❌ macOS CEF (shared `root_cache_path` → instance folding). |
-| `switchWindow` / `listWindows` (multi-window) | ✅ on Windows (WebView2, gated in CI); ⚠️ macOS CEF unreliable (2-window global-context race — run locally). |
-| `triggerDeeplink` | ⚠️ macOS — unreliable (no open-url routing to the spawned instance); ❌ Windows — upstream-blocked: Electrobun registers URL schemes + wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
+| **Linux** | 🧪 experimental — the native **WebKitGTK** renderer over W3C WebDriver (`WebKitWebDriver`, electrobun ≥ 2.0.1). Build `bundleCEF: false` / `defaultRenderer: 'native'`; install `webkit2gtk-driver`. A CEF build on Linux is unsupported (serves no `/json`). |
+| multiremote / parallel workers | ✅ Windows (WebView2 isolates each instance — its own process + `LOCALAPPDATA` data dir); ✅ Linux parallel workers (each gets its own `WebKitWebDriver` + app); ❌ macOS CEF (shared `root_cache_path` → instance folding). Linux multiremote (multiple instances per worker) not yet wired. |
+| `switchWindow` / `listWindows` (multi-window) | ✅ on Windows (WebView2, gated in CI); ⚠️ macOS CEF unreliable (2-window global-context race — run locally); ⚠️ Linux best-effort (W3C window handles, mapped by order). |
+| `triggerDeeplink` | ⚠️ macOS — unreliable (no open-url routing to the spawned instance); ❌ Windows/Linux — upstream-blocked: Electrobun registers URL schemes + wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
 | single-window apps | ⚠️ a lone CEF window doesn't reliably appear in `/json`, so the bridge can intermittently find no target to attach to. Opening a second window stabilises target exposure (the test fixtures do this, staggered behind the first window's `dom-ready`). |
 | `emitEvent` | deferred — the Bun event bus isn't CDP-reachable. |
 

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -121,8 +121,8 @@ tracked in [#320](https://github.com/webdriverio/desktop-mobile/issues/320); the
 | Area | Status |
 |---|---|
 | multiremote / parallel workers | ✅ Windows — WebView2 isolates each instance, so parallel workers and multiremote both work; ✅ Linux parallel workers, each with its own `WebKitWebDriver` + app; ⚠️ Linux multiremote (multiple instances per worker) not yet wired; ❌ macOS CEF — instances fold together, per the root cause above. |
-| `switchWindow` / `listWindows` | ✅ Windows; ⚠️ macOS CEF unreliable — a 2-window global-context race, so run locally; ⚠️ Linux best-effort — W3C window handles mapped by order. |
-| `triggerDeeplink` | ⚠️ macOS unreliable — no open-url routing to the spawned instance; ❌ Windows/Linux upstream-blocked — Electrobun registers URL schemes and wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
+| `switchWindow` / `listWindows` | ✅ Windows; ⚠️ macOS CEF unreliable — two windows race in the shared global context, so run locally; ⚠️ Linux best-effort — W3C window handles mapped by order. |
+| `triggerDeeplink` | ⚠️ macOS unreliable — no `open-url` routing to the spawned instance; ❌ Windows/Linux upstream-blocked — Electrobun registers URL schemes and wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |
 | single-window apps | ⚠️ a lone CEF window doesn't reliably appear in `/json`, so the bridge can intermittently find no target to attach to. Opening a second window stabilises target exposure — the fixtures open it staggered behind the first window's `dom-ready`. |
 | `emitEvent` | deferred — the Bun event bus isn't CDP-reachable. |
 

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -22,19 +22,20 @@ npm install --save-dev @wdio/electrobun-service
 
 ## Automation coverage (OS × renderer)
 
-The service drives each platform through whatever automation surface its renderer exposes:
-**CDP** for the Chromium renderers (macOS CEF, Windows WebView2 — the launcher spawns the app
-and a Chromedriver attaches via `debuggerAddress`), and **W3C WebDriver** for Linux's native
-WebKitGTK renderer (`WebKitWebDriver` launches the app and the worker drives it directly).
-Build each OS with its drivable renderer:
+Electrobun renders through either the **OS's native webview** (WKWebView on macOS, WebView2 on
+Windows, WebKitGTK on Linux) or a **bundled CEF** (Chromium) renderer. The service drives whichever
+exposes an automation surface: **CDP** for the Chromium-based renderers — macOS CEF and Windows
+WebView2, where the launcher spawns the app and a Chromedriver attaches via `debuggerAddress` — and
+**W3C WebDriver** for Linux WebKitGTK, where `WebKitWebDriver` launches the app and drives it
+directly. Build each OS with its drivable renderer:
 
 | OS | Renderer | Automation surface | Transport | Status |
 |---|---|---|---|---|
-| **macOS** | CEF (bundled Chromium) | CDP | Chromedriver attach | ✅ supported — recommended macOS path |
-| **macOS** | WKWebView (native) | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
-| **Windows** | WebView2 (native, Chromium) | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
+| **macOS** | CEF | CDP | Chromedriver attach | ✅ supported — recommended macOS path |
+| **macOS** | WKWebView | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
+| **Windows** | WebView2 | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
 | **Windows** | CEF | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
-| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported — single-window ([requirements](#linux-webkitgtk-requirements)) |
+| **Linux** | WebKitGTK | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported — single-window ([requirements](#linux-webkitgtk-requirements)) |
 | **Linux** | CEF | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
 
 ```ts
@@ -42,7 +43,7 @@ Build each OS with its drivable renderer:
 export default {
   build: {
     mac: { bundleCEF: true, defaultRenderer: 'cef' }, // WKWebView can't be driven → CEF (CDP)
-    win: { bundleCEF: false, defaultRenderer: 'native' }, // WebView2 (Chromium) over CDP
+    win: { bundleCEF: false, defaultRenderer: 'native' }, // WebView2 over CDP
     linux: { bundleCEF: false, defaultRenderer: 'native' }, // WebKitGTK over W3C WebDriver
   },
 };

--- a/packages/electrobun-service/README.md
+++ b/packages/electrobun-service/README.md
@@ -7,13 +7,11 @@ It mirrors the surface of the sibling services (`@wdio/electron-service`,
 `@wdio/tauri-service`, `@wdio/dioxus-service`): `browser.electrobun.execute`,
 Vitest-style mocking, log capture, browser mode, and standalone sessions.
 
-> **Status: `0.x.y`, pre-1.0 — macOS (CEF) + Windows (native WebView2) + Linux (WebKitGTK).**
-> Windows uses the native WebView2 (Chromium) renderer over CDP — no CEF — and runs multi-window
-> + multiremote. **Linux** drives the native WebKitGTK renderer over W3C WebDriver (electrobun ≥
-> 2.0.1; gated in CI); it needs `webkit2gtk-driver` installed and is single-window. This is still
-> a `0.x` release because the **macOS CEF** path has multiremote/deeplink blocked by an upstream
-> limitation. See [Known limitations](#known-limitations). `1.0` is reserved for full parity
-> once those gaps are filled ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
+> **Status: `0.x.y`, pre-1.0 — macOS (CEF), Windows (native WebView2), and Linux (WebKitGTK).**
+> See [Automation coverage](#automation-coverage-os--renderer) for the per-OS matrix. It's still a
+> `0.x` release because the **macOS CEF** path has multiremote and deeplink blocked upstream; `1.0`
+> is reserved for full parity once those gaps are filled
+> ([#317](https://github.com/webdriverio/desktop-mobile/issues/317) +
 > [#320](https://github.com/webdriverio/desktop-mobile/issues/320) track the work).
 
 ## Installation
@@ -35,9 +33,9 @@ Build each OS with its drivable renderer:
 | **macOS** | CEF (bundled Chromium) | CDP | Chromedriver attach | ✅ supported — recommended macOS path |
 | **macOS** | WKWebView (native) | none (local Web Inspector only) | — | ❌ unsupported — no remote automation surface; build with CEF. A future self-shipped embedded driver is tracked in [#629](https://github.com/webdriverio/desktop-mobile/issues/629). |
 | **Windows** | WebView2 (native, Chromium) | CDP | msedgedriver attach (classic) | ✅ supported — multi-window + multiremote |
-| **Windows** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
-| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported (electrobun ≥ 2.0.1) — needs `webkit2gtk-driver` installed; single-window |
-| **Linux** | CEF (bundled Chromium) | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
+| **Windows** | CEF | — | — | ❌ unsupported — CEF can't create its profile on Windows; use the native renderer |
+| **Linux** | WebKitGTK (native) | W3C WebDriver | `WebKitWebDriver` (classic) | ✅ supported — single-window ([requirements](#linux-webkitgtk-requirements)) |
+| **Linux** | CEF | — | — | ❌ unsupported — CEF serves no `/json` off macOS ([upstream #380](https://github.com/blackboardsh/electrobun/issues/380)); use the native renderer |
 
 ```ts
 // electrobun.config.ts — build each OS with its drivable renderer
@@ -50,9 +48,8 @@ export default {
 };
 ```
 
-A build with the **wrong renderer for its OS** is an explicit, documented unsupported
-configuration — the launcher fails fast with a clear error (WKWebView on macOS, or a CEF build
-on Windows/Linux where it serves no `/json`).
+A build with the **wrong renderer for its OS** (the ❌ rows above) is an explicit, documented
+unsupported configuration — the launcher fails fast with a clear error.
 
 ### Linux (WebKitGTK) requirements
 
@@ -66,7 +63,7 @@ sudo apt-get install webkit2gtk-driver xvfb            # Debian/Ubuntu
 # pacman -S webkit2gtk-driver xorg-server-xvfb         # Arch
 ```
 
-It requires **electrobun ≥ 2.0.1**, which exposes WebKitGTK automation upstream
+Native Linux support requires **electrobun ≥ 2.0.1**, which exposes WebKitGTK automation upstream
 ([blackboardsh/electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)). No CDP
 bridge is used on Linux — `browser.electrobun.execute` and mocking run over the W3C session.
 
@@ -113,20 +110,15 @@ Browser mode also supports the optional **`devServer`** service option — the l
 
 ## Known limitations
 
-Most of these are **upstream Electrobun/CEF limitations**, not service bugs — the
-service code implements the full surface and is unit-tested. On **macOS**, CEF's
-chrome-runtime can't create the `persist:default` profile its `BrowserWindow` forces and
-falls back to a global browser context (macOS recovers and serves `/json`; a CEF build off
-macOS does not — so **Windows** uses the native WebView2 renderer over CDP and **Linux** uses
-the native WebKitGTK renderer over W3C WebDriver instead). The upstream CEF fixes and what each
-unblocks are tracked in [#320](https://github.com/webdriverio/desktop-mobile/issues/320); the
-non-CEF (native-renderer) track is
-[#317](https://github.com/webdriverio/desktop-mobile/issues/317).
+Most of these are **upstream Electrobun/CEF limitations**, not service bugs — the service code
+implements the full surface and is unit-tested. The macOS root cause: CEF's chrome-runtime can't
+create the `persist:default` profile its `BrowserWindow` forces and falls back to a global browser
+context, which folds parallel instances together (blocking multiremote). Upstream CEF fixes are
+tracked in [#320](https://github.com/webdriverio/desktop-mobile/issues/320); the non-CEF
+(native-renderer) track is [#317](https://github.com/webdriverio/desktop-mobile/issues/317).
 
 | Area | Status |
 |---|---|
-| **Windows** | ✅ supported via the native **WebView2** (Chromium) renderer over CDP — no CEF (build `bundleCEF: false` / `defaultRenderer: 'native'`, the Electrobun default). |
-| **Linux** | ✅ supported via the native **WebKitGTK** renderer over W3C WebDriver (`WebKitWebDriver`, electrobun ≥ 2.0.1; gated in CI). Build `bundleCEF: false` / `defaultRenderer: 'native'`; install `webkit2gtk-driver`. Single-window (`switchWindow`/`listWindows` are best-effort). A CEF build on Linux is unsupported (serves no `/json`). |
 | multiremote / parallel workers | ✅ Windows (WebView2 isolates each instance — its own process + `LOCALAPPDATA` data dir); ✅ Linux parallel workers (each gets its own `WebKitWebDriver` + app); ❌ macOS CEF (shared `root_cache_path` → instance folding). Linux multiremote (multiple instances per worker) not yet wired. |
 | `switchWindow` / `listWindows` (multi-window) | ✅ on Windows (WebView2, gated in CI); ⚠️ macOS CEF unreliable (2-window global-context race — run locally); ⚠️ Linux best-effort (W3C window handles, mapped by order). |
 | `triggerDeeplink` | ⚠️ macOS — unreliable (no open-url routing to the spawned instance); ❌ Windows/Linux — upstream-blocked: Electrobun registers URL schemes + wires `open-url` macOS-only ([blackboardsh/electrobun#465](https://github.com/blackboardsh/electrobun/issues/465)). |

--- a/packages/electrobun-service/src/commands/triggerDeeplink.ts
+++ b/packages/electrobun-service/src/commands/triggerDeeplink.ts
@@ -6,8 +6,8 @@
 //
 // macOS-only in 0.x: Electrobun registers `app.urlSchemes` via the generated
 // Info.plist `CFBundleURLTypes`, and `open <url>` reaches the running app's
-// open-url handler. Windows/Linux deeplink support isn't available upstream yet
-// (RESEARCH_FINDINGS §6), so this rejects there with a documented-gap error.
+// open-url handler. Windows/Linux deeplink support isn't available upstream yet, so this
+// rejects there with a documented-gap error.
 
 import { executeDeeplinkCommand, getPlatformCommand, validateDeeplinkUrl } from '@wdio/native-core';
 import { createLogger } from '@wdio/native-utils';

--- a/packages/electrobun-service/src/electrobunConfig.ts
+++ b/packages/electrobun-service/src/electrobunConfig.ts
@@ -3,9 +3,9 @@
 //
 // Electrobun reads the CDP port EXCLUSIVELY from the bundle's
 // `Contents/Resources/build.json` `chromiumFlags["remote-debugging-port"]` at
-// runtime (a `--remote-debugging-port` launch arg does NOT reach CEF — see the
-// Phase 0 RESEARCH_FINDINGS). So to control the port the launcher writes it into
-// build.json. CEF's [9222, 9232] auto-scan is only a fallback when unset.
+// runtime (a `--remote-debugging-port` launch arg does NOT reach CEF). So to control
+// the port the launcher writes it into build.json. CEF's [9222, 9232] auto-scan is
+// only a fallback when unset.
 //
 // macOS is the validated platform. Windows/Linux bundle layout is unverified, so
 // resolution + the CEF check there are best-effort and guarded by existence

--- a/packages/electrobun-service/src/errors.ts
+++ b/packages/electrobun-service/src/errors.ts
@@ -28,11 +28,8 @@ export function cefRendererRequired(platform: NodeJS.Platform = process.platform
 
 /**
  * Thrown by the launcher in native mode when the current platform/renderer has no usable
- * automation surface. Driven native renderers: macOS via CEF (CDP), Windows via the WebView2
- * (Chromium) system renderer (CDP), Linux via the native WebKitGTK renderer (W3C WebDriver,
- * electrobun ≥ 2.0.1). A CEF build off macOS serves no `/json`, and non-desktop platforms have
- * no surface at all. Fail fast with an actionable message rather than letting the user hit a
- * cryptic attach timeout.
+ * automation surface — an explicit CEF build off macOS (serves no `/json`), or a non-desktop
+ * platform. Fails fast with an actionable message rather than a cryptic attach timeout.
  */
 export function nativeRendererUnsupportedPlatform(
   platform: NodeJS.Platform = process.platform,

--- a/packages/electrobun-service/src/errors.ts
+++ b/packages/electrobun-service/src/errors.ts
@@ -26,11 +26,7 @@ export function cefRendererRequired(platform: NodeJS.Platform = process.platform
   );
 }
 
-/**
- * Thrown by the launcher in native mode when the current platform/renderer has no usable
- * automation surface — an explicit CEF build off macOS (serves no `/json`), or a non-desktop
- * platform. Fails fast with an actionable message rather than a cryptic attach timeout.
- */
+/** Thrown in native mode when there's no automation surface: a CEF build off macOS, or a non-desktop platform. */
 export function nativeRendererUnsupportedPlatform(
   platform: NodeJS.Platform = process.platform,
   renderer?: string,
@@ -48,11 +44,7 @@ export function nativeRendererUnsupportedPlatform(
   );
 }
 
-/**
- * Thrown by the launcher when driving the Linux WebKitGTK renderer but the `WebKitWebDriver`
- * binary (from the `webkit2gtk-driver` package) can't be found. The W3C transport spawns this
- * driver to launch and drive the app, so it is a hard prerequisite on Linux.
- */
+/** Thrown when `WebKitWebDriver` (the `webkit2gtk-driver` package) is missing — required for the Linux W3C transport. */
 export function webKitWebDriverNotFound(): Error {
   return new SevereServiceError(
     '@wdio/electrobun-service could not find WebKitWebDriver, required to drive the Linux WebKitGTK ' +

--- a/packages/electrobun-service/src/errors.ts
+++ b/packages/electrobun-service/src/errors.ts
@@ -27,25 +27,41 @@ export function cefRendererRequired(platform: NodeJS.Platform = process.platform
 }
 
 /**
- * Thrown by the launcher in native mode when the current platform has no usable CDP
- * surface for the app's renderer. Driven native renderers: macOS via CEF, Windows via
- * the WebView2 (Chromium) system renderer over CDP. Linux's WebKitGTK exposes no
- * CDP/automation surface yet, and a CEF build on Windows/Linux serves no `/json`. Fail
- * fast with an actionable message rather than letting the user hit a cryptic CDP-attach
- * timeout.
+ * Thrown by the launcher in native mode when the current platform/renderer has no usable
+ * automation surface. Driven native renderers: macOS via CEF (CDP), Windows via the WebView2
+ * (Chromium) system renderer (CDP), Linux via the native WebKitGTK renderer (W3C WebDriver,
+ * electrobun ≥ 2.0.1). A CEF build off macOS serves no `/json`, and non-desktop platforms have
+ * no surface at all. Fail fast with an actionable message rather than letting the user hit a
+ * cryptic attach timeout.
  */
 export function nativeRendererUnsupportedPlatform(
   platform: NodeJS.Platform = process.platform,
   renderer?: string,
 ): Error {
+  const cefOffMac = (platform === 'win32' || platform === 'linux') && renderer === 'cef';
   return new SevereServiceError(
     `@wdio/electrobun-service cannot drive this Electrobun app in native mode on ${platform}` +
       (renderer ? ` (renderer: ${renderer})` : '') +
-      '. Supported native renderers: macOS via CEF, Windows via the WebView2 system renderer (CDP). ' +
-      'Linux (WebKitGTK) has no CDP/automation surface yet — tracked in ' +
-      'https://github.com/webdriverio/desktop-mobile/issues/317. On Windows, build with the native ' +
-      'renderer (bundleCEF: false / defaultRenderer: "native"); a CEF build there exposes no /json ' +
-      "endpoint. Otherwise run on macOS, or use browser mode (mode: 'browser').",
+      '. Supported native renderers: macOS via CEF, Windows via the WebView2 system renderer (CDP), ' +
+      'Linux via the native WebKitGTK renderer (W3C WebDriver, electrobun >= 2.0.1). ' +
+      (cefOffMac
+        ? `A CEF build exposes no /json endpoint on ${platform} — build with the native renderer instead ` +
+          '(bundleCEF: false / defaultRenderer: "native"), which is the Electrobun default.'
+        : "This platform has no automation surface — run on macOS/Windows/Linux, or use browser mode (mode: 'browser')."),
+  );
+}
+
+/**
+ * Thrown by the launcher when driving the Linux WebKitGTK renderer but the `WebKitWebDriver`
+ * binary (from the `webkit2gtk-driver` package) can't be found. The W3C transport spawns this
+ * driver to launch and drive the app, so it is a hard prerequisite on Linux.
+ */
+export function webKitWebDriverNotFound(): Error {
+  return new SevereServiceError(
+    '@wdio/electrobun-service could not find WebKitWebDriver, required to drive the Linux WebKitGTK ' +
+      'renderer over W3C WebDriver. Install it with `sudo apt-get install webkit2gtk-driver` ' +
+      '(Debian/Ubuntu; `dnf install webkit2gtk-driver`, `pacman -S webkit2gtk-driver`, or your ' +
+      "distribution's equivalent), or put WebKitWebDriver on PATH.",
   );
 }
 

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -10,11 +10,17 @@ import type { Options } from '@wdio/types';
 
 import { CUSTOM_CAPABILITY_NAME, DEFAULT_DEBUG_PORT_BASE, SERVICE_NAME } from './constants.js';
 import { type ResolvedElectrobunApp, resolveElectrobunApp, verifyCefRenderer } from './electrobunConfig.js';
-import { nativeRendererUnsupportedPlatform, SevereServiceError } from './errors.js';
+import { nativeRendererUnsupportedPlatform, SevereServiceError, webKitWebDriverNotFound } from './errors.js';
 import { type ElectrobunAppProcess, spawnElectrobunApp, stopElectrobunApp, waitForCdpReady } from './nativeMode.js';
 import { getServiceOptionsFromCapability, mergeServiceOptions } from './serviceConfig.js';
 import { resolveTransport } from './transport.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions, ElectrobunServiceOptions } from './types.js';
+import {
+  getWebKitWebDriverPath,
+  spawnWebKitWebDriver,
+  stopWebKitWebDriver,
+  type WebKitDriverProcess,
+} from './webkitDriver.js';
 import { detectWebView2RuntimeVersion } from './webview2Version.js';
 
 const log = createLogger(SERVICE_NAME, 'launcher');
@@ -58,6 +64,17 @@ export default class ElectrobunLaunchService extends BaseLauncher {
    * stragglers (e.g. a worker that never reported end).
    */
   private spawnedAppsByCid = new Map<string, ElectrobunAppProcess[]>();
+  /**
+   * Resolved `WebKitWebDriver` path for the Linux WebKitGTK (W3C) transport, set in onPrepare
+   * when any app resolves to that transport.
+   */
+  private webkitDriverPath?: string;
+  /**
+   * Spawned `WebKitWebDriver` processes keyed by worker cid (WebKitGTK/W3C transport). Unlike
+   * the CDP path — where the service spawns the app — here the driver launches the app, so we
+   * track the driver for teardown; killing it tears the app down too.
+   */
+  private webkitDriversByCid = new Map<string, WebKitDriverProcess[]>();
 
   constructor(
     private options: ElectrobunServiceGlobalOptions,
@@ -166,13 +183,12 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       return;
     }
 
-    // Native renderer automation covers macOS (CEF) and Windows (WebView2 over CDP).
-    // Linux's WebKitGTK exposes no CDP/automation surface yet, and CEF-on-Linux serves no
-    // /json — fail fast here, before touching the bundle, rather than let the user hit a
-    // cryptic CDP-attach timeout. Browser mode is unaffected — it already returned above.
-    // The per-app renderer→transport decision (and the CEF-on-Windows rejection) happens in
-    // the resolve loop below.
-    if (process.platform !== 'darwin' && process.platform !== 'win32') {
+    // Native renderer automation covers macOS (CEF/CDP), Windows (WebView2/CDP), and Linux
+    // (WebKitGTK/W3C WebDriver, electrobun >= 2.0.1). Non-desktop platforms have no surface at
+    // all — fail fast here, before touching the bundle. Browser mode is unaffected (it already
+    // returned above). The per-app renderer→transport decision (and the CEF-off-macOS rejection)
+    // happens in the resolve loop below.
+    if (process.platform !== 'darwin' && process.platform !== 'win32' && process.platform !== 'linux') {
       throw nativeRendererUnsupportedPlatform(process.platform);
     }
 
@@ -209,10 +225,26 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         verifyCefRenderer(app);
       }
       this.resolvedApps.push(app);
-      // CEF is plain Chromium → chromedriver. WebView2 is Edge (it reports `Edg/<ver>`,
-      // which chromedriver rejects as an "unrecognized Chrome version"), so it must be
-      // driven by msedgedriver → browserName 'MicrosoftEdge' (WDIO provisions edgedriver).
-      (cap as { browserName?: string }).browserName = transport === 'webview2' ? 'MicrosoftEdge' : 'chrome';
+      if (transport === 'webkitgtk') {
+        // W3C WebDriver: WDIO connects directly to WebKitWebDriver (hostname/port set per worker
+        // in onWorkerStart). Set the static caps here:
+        //  - delete browserName (else WDIO tries to provision a Chromium driver);
+        //  - enforce classic — WebKitWebDriver has no BiDi, so skip the failing BiDi handshake;
+        //  - browserOptions.binary + `--automation`: WebKitWebDriver LAUNCHES the app, and the
+        //    flag makes electrobun opt the webview into automation (2.0.1, #467).
+        const w3cCap = cap as Record<string, unknown>;
+        delete w3cCap.browserName;
+        w3cCap['wdio:enforceWebDriverClassic'] = true;
+        w3cCap['webkitgtk:browserOptions'] = {
+          binary: app.binaryPath,
+          args: ['--automation', ...(instanceOptions.appArgs ?? [])],
+        };
+      } else {
+        // CEF is plain Chromium → chromedriver. WebView2 is Edge (it reports `Edg/<ver>`,
+        // which chromedriver rejects as an "unrecognized Chrome version"), so it must be
+        // driven by msedgedriver → browserName 'MicrosoftEdge' (WDIO provisions edgedriver).
+        (cap as { browserName?: string }).browserName = transport === 'webview2' ? 'MicrosoftEdge' : 'chrome';
+      }
       // The WebView2 runtime can lag the Edge browser WDIO auto-matches; a mismatched
       // msedgedriver then refuses to attach ("only supports Microsoft Edge version N"). Pin the
       // driver to the runtime version instead, respecting any user-set browserVersion. If the
@@ -233,6 +265,18 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         }
       }
     }
+
+    // WebKitGTK (Linux/W3C): resolve WebKitWebDriver once, up front, so a missing driver fails
+    // with an actionable install error before any worker starts (rather than a per-worker spawn
+    // failure). The driver launches the app when the worker opens its session.
+    if (this.resolvedApps.some((app) => resolveTransport(app) === 'webkitgtk')) {
+      this.webkitDriverPath = getWebKitWebDriverPath();
+      if (!this.webkitDriverPath) {
+        throw webKitWebDriverNotFound();
+      }
+      log.debug(`Using WebKitWebDriver at ${this.webkitDriverPath}`);
+    }
+
     log.info(`Native mode prepared ${this.resolvedApps.length} Electrobun app(s)`);
   }
 
@@ -272,9 +316,28 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
       const port = await this.portManager.allocatePort(this.options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE);
 
-      // The allocated port is pinned into the per-worker bundle clone inside
-      // spawnApp — the CEF port is fixed per bundle (a launch arg does NOT work,
-      // see RESEARCH_FINDINGS), so the clone is what makes parallel workers safe.
+      // WebKitGTK (Linux/W3C): the driver launches the app, so spawn WebKitWebDriver on the
+      // allocated port and point WDIO's connection at it — no app spawn / CDP wait here. Each
+      // worker gets its own driver + app, so parallel workers isolate cleanly.
+      if (resolveTransport(app) === 'webkitgtk') {
+        // webkitDriverPath is resolved (and validated) in onPrepare whenever any app is webkitgtk.
+        const driver = await this.spawnWebKitDriver(this.webkitDriverPath ?? '', port);
+        const drivers = this.webkitDriversByCid.get(cid) ?? [];
+        drivers.push(driver);
+        this.webkitDriversByCid.set(cid, drivers);
+        // hostname/port are connection params (not capabilities): WDIO connects to WebKitWebDriver
+        // as a classic W3C remote end. Set here because the port is allocated per worker.
+        const w3cCap = cap as Record<string, unknown>;
+        w3cCap.hostname = driver.host;
+        w3cCap.port = driver.port;
+        log.info(`Worker ${cid}: WebKitWebDriver on ${driver.host}:${driver.port} → ${app.binaryPath}`);
+        continue;
+      }
+
+      // CDP-attach (cef/webview2): spawn the app; a Chromedriver attaches via debuggerAddress.
+      // The allocated port is pinned into the per-worker bundle clone inside spawnApp — the CEF
+      // port is fixed per bundle (a launch arg does NOT work, see RESEARCH_FINDINGS), so the
+      // clone is what makes parallel workers safe.
       const spawned = this.spawnApp(app, port, instanceOptions, cid);
       workerApps.push(spawned);
 
@@ -308,14 +371,23 @@ export default class ElectrobunLaunchService extends BaseLauncher {
   /** Tear down this worker's app(s) when its spec finishes, so they don't accumulate. */
   async onWorkerEnd(cid: string): Promise<void> {
     const apps = this.spawnedAppsByCid.get(cid);
-    if (!apps) {
-      return;
+    if (apps) {
+      this.spawnedAppsByCid.delete(cid);
+      for (const app of apps) {
+        await stopElectrobunApp(app).catch((error: Error) => {
+          log.warn(`Worker ${cid}: failed to stop Electrobun app: ${error.message}`);
+        });
+      }
     }
-    this.spawnedAppsByCid.delete(cid);
-    for (const app of apps) {
-      await stopElectrobunApp(app).catch((error: Error) => {
-        log.warn(`Worker ${cid}: failed to stop Electrobun app: ${error.message}`);
-      });
+    // WebKitGTK/W3C: kill the driver (which tears down the app it launched).
+    const drivers = this.webkitDriversByCid.get(cid);
+    if (drivers) {
+      this.webkitDriversByCid.delete(cid);
+      for (const driver of drivers) {
+        await stopWebKitWebDriver(driver).catch((error: Error) => {
+          log.warn(`Worker ${cid}: failed to stop WebKitWebDriver: ${error.message}`);
+        });
+      }
     }
   }
 
@@ -335,6 +407,11 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     });
   }
 
+  // Seam for unit tests to assert WebKitWebDriver wiring without spawning a real process.
+  protected spawnWebKitDriver(driverPath: string, port: number): Promise<WebKitDriverProcess> {
+    return spawnWebKitWebDriver({ driverPath, port });
+  }
+
   async onComplete(): Promise<void> {
     await this.#stopDevServer?.();
     this.#stopDevServer = undefined;
@@ -346,6 +423,14 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       }
     }
     this.spawnedAppsByCid.clear();
+    for (const drivers of this.webkitDriversByCid.values()) {
+      for (const driver of drivers) {
+        await stopWebKitWebDriver(driver).catch((error: Error) => {
+          log.warn(`Failed to stop WebKitWebDriver: ${error.message}`);
+        });
+      }
+    }
+    this.webkitDriversByCid.clear();
 
     await this.stopAllDrivers();
     if (isLogWriterInitialized(SERVICE_NAME)) {

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -314,7 +314,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       }
 
       // spawnApp pins the port into a per-worker bundle clone — CEF's debug port is fixed per
-      // bundle, so a launch arg can't set it (see RESEARCH_FINDINGS).
+      // bundle, so a launch arg can't set it.
       const spawned = this.spawnApp(app, port, instanceOptions, cid);
       workerApps.push(spawned);
 

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -70,9 +70,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
    */
   private webkitDriverPath?: string;
   /**
-   * Spawned `WebKitWebDriver` processes keyed by worker cid (WebKitGTK/W3C transport). Unlike
-   * the CDP path — where the service spawns the app — here the driver launches the app, so we
-   * track the driver for teardown; killing it tears the app down too.
+   * Spawned `WebKitWebDriver` processes keyed by worker cid (WebKitGTK/W3C transport). Unlike the
+   * CDP path — where the service spawns the app — here the driver launches the app, so we track
+   * the driver to stop it on teardown.
    */
   private webkitDriversByCid = new Map<string, WebKitDriverProcess[]>();
 

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -28,10 +28,9 @@ const log = createLogger(SERVICE_NAME, 'launcher');
 /**
  * Main-process launcher for `@wdio/electrobun-service`.
  *
- * Electrobun is a CDP-attach framework: the launcher spawns the app binary and the worker
- * attaches over CDP via `debuggerAddress`. It extends `BaseLauncher` to reuse
- * `@wdio/native-core`'s port/process/log infra. The CDP transport is per platform
- * (see `resolveTransport`):
+ * Extends `BaseLauncher` to reuse `@wdio/native-core`'s port/process/log infra. The transport is
+ * per platform (see `resolveTransport`); macOS/Windows are CDP-attach (the launcher spawns the app
+ * and the worker attaches over CDP via `debuggerAddress`), Linux is W3C (the driver launches the app):
  *  - **macOS → CEF** (Chromium), driven by **chromedriver** (`browserName: 'chrome'`,
  *    `goog:chromeOptions.debuggerAddress`). Single-instance (`maxInstances=1`): CEF can't
  *    isolate the forced `persist:default` profile per worker, so we do NOT redirect the cache
@@ -40,15 +39,18 @@ const log = createLogger(SERVICE_NAME, 'launcher');
  *  - **Windows → native WebView2** (Edge-based Chromium), driven by **msedgedriver**
  *    (`browserName: 'MicrosoftEdge'`, `ms:edgeOptions.debuggerAddress`). Isolates per instance
  *    (its own `LOCALAPPDATA` data root), so parallel workers + multiremote work.
- *  - **Linux** has no CDP/automation surface yet → unsupported (fail fast). See #320.
+ *  - **Linux → native WebKitGTK** over W3C WebDriver (electrobun >= 2.0.1, #467), driven by
+ *    **WebKitWebDriver**, which launches the app itself — no CDP, no app spawn here.
  *
  * Native-mode flow:
  *  - `onPrepare`: resolve each bundle + pick its transport; CEF-verify (CEF only); force
- *    `browserName`; pin the driver to the WebView2 runtime version (WebView2 only).
- *  - `onWorkerStart`: allocate a port; spawn the app — CEF clones the bundle and pins the port
- *    into the clone's `build.json`, WebView2 injects `--remote-debugging-port` via env — wait
- *    for `/json`, then set the `debuggerAddress`.
- *  - `onComplete`: kill spawned apps + clean temp dirs.
+ *    `browserName` (WebKitGTK deletes it + forces classic); pin the driver to the WebView2 runtime
+ *    version (WebView2 only); resolve WebKitWebDriver once (WebKitGTK only).
+ *  - `onWorkerStart`: allocate a port; CDP paths spawn the app (CEF clones the bundle and pins the
+ *    port into the clone's `build.json`, WebView2 injects `--remote-debugging-port` via env) then
+ *    wait for `/json` and set the `debuggerAddress`; WebKitGTK spawns the driver and sets
+ *    hostname/port instead.
+ *  - `onComplete`: kill spawned apps/drivers + clean temp dirs.
  */
 export default class ElectrobunLaunchService extends BaseLauncher {
   private browserMode = false;
@@ -64,16 +66,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
    * stragglers (e.g. a worker that never reported end).
    */
   private spawnedAppsByCid = new Map<string, ElectrobunAppProcess[]>();
-  /**
-   * Resolved `WebKitWebDriver` path for the Linux WebKitGTK (W3C) transport, set in onPrepare
-   * when any app resolves to that transport.
-   */
   private webkitDriverPath?: string;
-  /**
-   * Spawned `WebKitWebDriver` processes keyed by worker cid (WebKitGTK/W3C transport). Unlike the
-   * CDP path — where the service spawns the app — here the driver launches the app, so we track
-   * the driver to stop it on teardown.
-   */
   private webkitDriversByCid = new Map<string, WebKitDriverProcess[]>();
 
   constructor(
@@ -183,11 +176,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       return;
     }
 
-    // Native renderer automation covers macOS (CEF/CDP), Windows (WebView2/CDP), and Linux
-    // (WebKitGTK/W3C WebDriver, electrobun >= 2.0.1). Non-desktop platforms have no surface at
-    // all — fail fast here, before touching the bundle. Browser mode is unaffected (it already
-    // returned above). The per-app renderer→transport decision (and the CEF-off-macOS rejection)
-    // happens in the resolve loop below.
+    // Only desktop platforms have an automation surface — fail fast before touching the bundle.
     if (process.platform !== 'darwin' && process.platform !== 'win32' && process.platform !== 'linux') {
       throw nativeRendererUnsupportedPlatform(process.platform);
     }
@@ -226,11 +215,10 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       }
       this.resolvedApps.push(app);
       if (transport === 'webkitgtk') {
-        // W3C WebDriver: WDIO connects directly to WebKitWebDriver (hostname/port set per worker
-        // in onWorkerStart). Set the static caps here:
+        // W3C static caps (hostname/port are set per worker in onWorkerStart):
         //  - delete browserName (else WDIO tries to provision a Chromium driver);
         //  - enforce classic — WebKitWebDriver has no BiDi, so skip the failing BiDi handshake;
-        //  - browserOptions.binary + `--automation`: WebKitWebDriver LAUNCHES the app, and the
+        //  - browserOptions.binary + `--automation`: WebKitWebDriver launches the app, and the
         //    flag makes electrobun opt the webview into automation (2.0.1, #467).
         const w3cCap = cap as Record<string, unknown>;
         delete w3cCap.browserName;
@@ -266,9 +254,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       }
     }
 
-    // WebKitGTK (Linux/W3C): resolve WebKitWebDriver once, up front, so a missing driver fails
-    // with an actionable install error before any worker starts (rather than a per-worker spawn
-    // failure). The driver launches the app when the worker opens its session.
+    // Resolve WebKitWebDriver once so a missing driver fails fast, before any worker starts.
     if (this.resolvedApps.some((app) => resolveTransport(app) === 'webkitgtk')) {
       this.webkitDriverPath = getWebKitWebDriverPath();
       if (!this.webkitDriverPath) {
@@ -316,17 +302,14 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       const instanceOptions = mergeServiceOptions(this.options, getServiceOptionsFromCapability(cap));
       const port = await this.portManager.allocatePort(this.options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE);
 
-      // WebKitGTK (Linux/W3C): the driver launches the app, so spawn WebKitWebDriver on the
-      // allocated port and point WDIO's connection at it — no app spawn / CDP wait here. Each
-      // worker gets its own driver + app, so parallel workers isolate cleanly.
+      // W3C: the driver launches the app — no app spawn / CDP wait here (unlike the CDP path).
       if (resolveTransport(app) === 'webkitgtk') {
-        // webkitDriverPath is resolved (and validated) in onPrepare whenever any app is webkitgtk.
         const driver = await this.spawnWebKitDriver(this.webkitDriverPath ?? '', port);
         const drivers = this.webkitDriversByCid.get(cid) ?? [];
         drivers.push(driver);
         this.webkitDriversByCid.set(cid, drivers);
-        // hostname/port are connection params (not capabilities): WDIO connects to WebKitWebDriver
-        // as a classic W3C remote end. Set here because the port is allocated per worker.
+        // hostname/port are connection params (not capabilities), set per worker as the port is
+        // allocated here.
         const w3cCap = cap as Record<string, unknown>;
         w3cCap.hostname = driver.host;
         w3cCap.port = driver.port;
@@ -334,7 +317,6 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         continue;
       }
 
-      // CDP-attach (cef/webview2): spawn the app; a Chromedriver attaches via debuggerAddress.
       // The allocated port is pinned into the per-worker bundle clone inside spawnApp — the CEF
       // port is fixed per bundle (a launch arg does NOT work, see RESEARCH_FINDINGS), so the
       // clone is what makes parallel workers safe.
@@ -379,7 +361,6 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         });
       }
     }
-    // WebKitGTK/W3C: kill the driver (which tears down the app it launched).
     const drivers = this.webkitDriversByCid.get(cid);
     if (drivers) {
       this.webkitDriversByCid.delete(cid);

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -180,14 +180,17 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       throw nativeRendererUnsupportedPlatform(process.platform);
     }
 
-    // CEF (macOS) can't isolate ≥2 app instances, so parallel workers race there (#320); WebView2
-    // (Windows) isolates each, so only macOS warns. WDIO's default maxInstances is 100, so this
-    // can't be a hard error.
-    if (process.platform === 'darwin' && (config.maxInstances ?? 1) > 1) {
-      log.warn(
-        `maxInstances is ${config.maxInstances}, but Electrobun CEF on macOS is single-instance: parallel ` +
-          'workers share one CEF cache root and race ("Cannot create profile" / CDP timeouts). Pin maxInstances: 1.',
-      );
+    // Neither macOS nor Linux isolates ≥2 app instances of one bundle: CEF (macOS) shares a single
+    // cache root and races (#320); the WebKitGTK (Linux) apps launch from the same bundle path and
+    // teardown reaps by that path (service.ts), so one worker's cleanup SIGKILLs its siblings.
+    // WebView2 (Windows) isolates each worker, so it needs no guard. WDIO's default maxInstances is
+    // 100, so this can't be a hard error — warn and let the user pin maxInstances: 1.
+    if ((process.platform === 'darwin' || process.platform === 'linux') && (config.maxInstances ?? 1) > 1) {
+      const reason =
+        process.platform === 'darwin'
+          ? 'Electrobun CEF on macOS is single-instance: parallel workers share one CEF cache root and race ("Cannot create profile" / CDP timeouts)'
+          : 'Electrobun on Linux shares one WebKitGTK app bundle: parallel workers launch from the same path and teardown reaps by it, cross-killing siblings';
+      log.warn(`maxInstances is ${config.maxInstances}, but ${reason}. Pin maxInstances: 1.`);
     }
 
     // Native mode: resolve each bundle and pick its transport (the capability is set per transport

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -39,8 +39,8 @@ const log = createLogger(SERVICE_NAME, 'launcher');
  *  - **Windows → native WebView2** (Edge-based Chromium), driven by **msedgedriver**
  *    (`browserName: 'MicrosoftEdge'`, `ms:edgeOptions.debuggerAddress`). Isolates per instance
  *    (its own `LOCALAPPDATA` data root), so parallel workers + multiremote work.
- *  - **Linux → native WebKitGTK** over W3C WebDriver (electrobun >= 2.0.1, #467), driven by
- *    **WebKitWebDriver**, which launches the app itself — no CDP, no app spawn here.
+ *  - **Linux → native WebKitGTK** over W3C WebDriver, driven by **WebKitWebDriver**, which
+ *    launches the app itself — no CDP, no app spawn here.
  *
  * Native-mode flow:
  *  - `onPrepare`: resolve each bundle + pick its transport; CEF-verify (CEF only); force
@@ -77,10 +77,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
     const basePort = options.remoteDebuggingPort ?? DEFAULT_DEBUG_PORT_BASE;
     super({
       basePort,
-      // Electrobun is CDP-attach: there is no separate native driver process, so
-      // baseNativePort is nominal. Anchored alongside basePort, clear of CEF's
-      // [9222, 9232] auto-scan range so PortManager never hands out a port CEF
-      // might grab for an un-pinned app.
+      // Nothing binds baseNativePort, so it's nominal — anchor it alongside basePort,
+      // clear of CEF's [9222, 9232] auto-scan range so PortManager never hands out a
+      // port CEF might grab for an un-pinned app.
       baseNativePort: basePort + 1,
     });
     // Don't serialise the full testrunner config/capabilities — they can carry
@@ -181,10 +180,9 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       throw nativeRendererUnsupportedPlatform(process.platform);
     }
 
-    // CEF (macOS) can't isolate ≥2 app instances (shared root_cache_path → instance folding;
-    // upstream-blocked, #320), so parallel workers race there. WebView2 (Windows) isolates
-    // each instance (its own LOCALAPPDATA data root), so parallel workers + multiremote work —
-    // only warn on macOS. WDIO's default maxInstances is 100, so this can't be a hard error.
+    // CEF (macOS) can't isolate ≥2 app instances, so parallel workers race there (#320); WebView2
+    // (Windows) isolates each, so only macOS warns. WDIO's default maxInstances is 100, so this
+    // can't be a hard error.
     if (process.platform === 'darwin' && (config.maxInstances ?? 1) > 1) {
       log.warn(
         `maxInstances is ${config.maxInstances}, but Electrobun CEF on macOS is single-instance: parallel ` +
@@ -192,11 +190,10 @@ export default class ElectrobunLaunchService extends BaseLauncher {
       );
     }
 
-    // Native mode: resolve each bundle, pick its CDP transport, force chrome capability.
-    // The spawn (CEF clone+port-pin, or WebView2 env-var injection) happens in
-    // onWorkerStart so each worker gets a freshly allocated port.
-    // WebView2 (Windows) only: detect the installed runtime version once so the loop can pin
-    // msedgedriver to it (see the per-cap note below). Off Windows this is skipped.
+    // Native mode: resolve each bundle and pick its transport (the capability is set per transport
+    // below). Spawning happens in onWorkerStart so each worker gets a freshly allocated port.
+    // WebView2 only: detect the runtime version once here so the loop can pin msedgedriver to it
+    // (see the per-cap note below).
     const webview2Version = process.platform === 'win32' ? detectWebView2RuntimeVersion() : undefined;
     let warnedNoWebView2Version = false;
     this.resolvedApps = [];
@@ -219,7 +216,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         //  - delete browserName (else WDIO tries to provision a Chromium driver);
         //  - enforce classic — WebKitWebDriver has no BiDi, so skip the failing BiDi handshake;
         //  - browserOptions.binary + `--automation`: WebKitWebDriver launches the app, and the
-        //    flag makes electrobun opt the webview into automation (2.0.1, #467).
+        //    flag makes electrobun opt the webview into automation.
         const w3cCap = cap as Record<string, unknown>;
         delete w3cCap.browserName;
         w3cCap['wdio:enforceWebDriverClassic'] = true;
@@ -288,9 +285,8 @@ export default class ElectrobunLaunchService extends BaseLauncher {
 
     for (let i = 0; i < capsList.length; i++) {
       const cap = capsList[i];
-      // The resolved bundle is the source template; each worker (cid) clones it
-      // and pins its own port inside spawnApp, so one resolved app safely drives
-      // any number of parallel workers.
+      // The resolved bundle is a shared template: one resolved app safely drives any number of
+      // parallel workers, each spawned with its own freshly allocated port.
       const app = this.resolvedApps[i] ?? this.resolvedApps[0];
       if (!app) {
         throw new SevereServiceError(
@@ -317,9 +313,8 @@ export default class ElectrobunLaunchService extends BaseLauncher {
         continue;
       }
 
-      // The allocated port is pinned into the per-worker bundle clone inside spawnApp — the CEF
-      // port is fixed per bundle (a launch arg does NOT work, see RESEARCH_FINDINGS), so the
-      // clone is what makes parallel workers safe.
+      // spawnApp pins the port into a per-worker bundle clone — CEF's debug port is fixed per
+      // bundle, so a launch arg can't set it (see RESEARCH_FINDINGS).
       const spawned = this.spawnApp(app, port, instanceOptions, cid);
       workerApps.push(spawned);
 

--- a/packages/electrobun-service/src/launcher.ts
+++ b/packages/electrobun-service/src/launcher.ts
@@ -182,7 +182,7 @@ export default class ElectrobunLaunchService extends BaseLauncher {
 
     // Neither macOS nor Linux isolates ≥2 app instances of one bundle: CEF (macOS) shares a single
     // cache root and races (#320); the WebKitGTK (Linux) apps launch from the same bundle path and
-    // teardown reaps by that path (service.ts), so one worker's cleanup SIGKILLs its siblings.
+    // teardown reaps by that path (service.ts), so one worker's cleanup SIGKILLs its siblings (#633).
     // WebView2 (Windows) isolates each worker, so it needs no guard. WDIO's default maxInstances is
     // 100, so this can't be a hard error — warn and let the user pin maxInstances: 1.
     if ((process.platform === 'darwin' || process.platform === 'linux') && (config.maxInstances ?? 1) > 1) {

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -40,12 +40,7 @@ export default class ElectrobunWorkerService {
   private mockStores: ElectrobunMockStore[] = [];
   /** Console-shim drains (Linux/W3C path only), flushed to the logger on teardown. */
   private consoleDrains: Array<() => Promise<void>> = [];
-  /**
-   * App launcher paths driven over W3C (WebKitGTK), captured to reap the app tree on teardown.
-   * WebKitWebDriver can't cleanly close the app's controlled webview, so `DELETE /session` hangs
-   * (~120s) unless the app is already gone — killing it in `after` (before WDIO's deleteSession)
-   * makes teardown return in milliseconds and reaps the process tree.
-   */
+  /** App launcher paths driven over W3C (WebKitGTK), reaped on teardown — see `reapW3CApps`. */
   private w3cAppBinaries: string[] = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
@@ -150,14 +145,11 @@ export default class ElectrobunWorkerService {
     await syncWebDriverWindow(browser, bridge);
   }
 
-  /** Install `browser.electrobun.*` over the W3C session (Linux/WebKitGTK path). */
   private async attachW3CInstance(browser: WebdriverIO.Browser): Promise<void> {
     log.info('Installing browser.electrobun.* over W3C WebDriver (WebKitGTK)');
     const evalBridge = createWebDriverEvalBridge(browser);
     const mockStore = new ElectrobunMockStore();
     this.mockStores.push(mockStore);
-    // Frontend log capture without CDP console events: buffer console.* in-page, drain to the
-    // logger on teardown. (Live frontend logs also surface via the driver's stdout.)
     const drain = await installConsoleShim(browser);
     this.consoleDrains.push(drain);
     installApiW3C(browser, evalBridge, mockStore);
@@ -209,7 +201,6 @@ export default class ElectrobunWorkerService {
   }
 
   private async closeBridges(): Promise<void> {
-    // Flush any buffered frontend console entries (W3C path) before tearing down the session.
     for (const drain of this.consoleDrains) {
       await drain().catch(() => {});
     }
@@ -308,9 +299,9 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: 
 
 /**
  * Map a window label ('main', 'window-1', …) to a W3C window-handle index, or -1 for an
- * unrecognised label (so the caller rejects rather than silently targeting window 0). NOTE:
- * W3C `getWindowHandles` order is unspecified, so index→window is best-effort — multi-window on
- * Linux is experimental (see the README). Single-window ('standard') runs never index past 0.
+ * unrecognised label (so the caller rejects rather than silently targeting window 0). W3C
+ * `getWindowHandles` order is unspecified, so index→window is best-effort; the single-window
+ * 'standard' runs never index past 0.
  */
 function w3cWindowIndex(label: string): number {
   if (label === 'main') {

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -38,9 +38,7 @@ export default class ElectrobunWorkerService {
   private options: ElectrobunServiceOptions;
   private bridges: CdpBridge[] = [];
   private mockStores: ElectrobunMockStore[] = [];
-  /** Console-shim drains (Linux/W3C path only), flushed to the logger on teardown. */
   private consoleDrains: Array<() => Promise<void>> = [];
-  /** App launcher paths driven over W3C (WebKitGTK), reaped on teardown — see `reapW3CApps`. */
   private w3cAppBinaries: string[] = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
@@ -79,10 +77,8 @@ export default class ElectrobunWorkerService {
   }
 
   private async attachInstance(browser: WebdriverIO.Browser, capabilities: unknown): Promise<void> {
-    // Linux/W3C (WebKitGTK): the WDIO session IS the WebKitWebDriver session — there is no CDP
-    // side-channel. The launcher marks this path with a `webkitgtk:browserOptions` capability.
-    // Drive the app over W3C `browser.execute` (via the eval adapter), reusing the CDP
-    // execute/mock machinery unchanged.
+    // Linux/W3C: no CDP side-channel — the WDIO session IS the WebKitWebDriver session, flagged
+    // by the launcher's `webkitgtk:browserOptions` cap.
     const w3cOptions = (capabilities as { 'webkitgtk:browserOptions'?: { binary?: string } } | undefined)?.[
       'webkitgtk:browserOptions'
     ];
@@ -156,8 +152,8 @@ export default class ElectrobunWorkerService {
   }
 
   async after(): Promise<void> {
-    // Drain the console shim (needs the session alive) and close bridges FIRST, then reap the app
-    // — `after` runs before WDIO's deleteSession, so reaping here makes that DELETE return in ms.
+    // `after` runs before WDIO's deleteSession, so reaping the app here makes that DELETE return
+    // in ms (not ~120s). closeBridges() first — the console-shim drain needs the session alive.
     await this.closeBridges();
     this.reapW3CApps();
   }
@@ -298,10 +294,8 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: 
 }
 
 /**
- * Map a window label ('main', 'window-1', …) to a W3C window-handle index, or -1 for an
- * unrecognised label (so the caller rejects rather than silently targeting window 0). W3C
- * `getWindowHandles` order is unspecified, so index→window is best-effort; the single-window
- * 'standard' runs never index past 0.
+ * -1 for an unrecognised label so `switchWindow` rejects instead of silently targeting window 0.
+ * W3C `getWindowHandles` order is unspecified, so the index→window mapping is best-effort.
  */
 function w3cWindowIndex(label: string): number {
   if (label === 'main') {
@@ -311,12 +305,6 @@ function w3cWindowIndex(label: string): number {
   return match ? Number.parseInt(match[1], 10) : -1;
 }
 
-/**
- * Install `browser.electrobun.*` for the W3C (WebKitGTK) transport. `execute` and `mock` reuse
- * the CDP machinery unchanged via the `WebDriverEvalBridge` adapter (only its `send` is used);
- * window switching goes through W3C window handles, and `triggerDeeplink` stays unsupported off
- * macOS (the shared command already throws).
- */
 function installApiW3C(
   browser: WebdriverIO.Browser,
   evalBridge: WebDriverEvalBridge,

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -253,13 +253,18 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: 
   log.debug('Installed browser.electrobun.*');
 }
 
-/** Map a window label ('main', 'window-1', …) to a W3C window-handle index. */
+/**
+ * Map a window label ('main', 'window-1', …) to a W3C window-handle index, or -1 for an
+ * unrecognised label (so the caller rejects rather than silently targeting window 0). NOTE:
+ * W3C `getWindowHandles` order is unspecified, so index→window is best-effort — multi-window on
+ * Linux is experimental (see the README). Single-window ('standard') runs never index past 0.
+ */
 function w3cWindowIndex(label: string): number {
   if (label === 'main') {
     return 0;
   }
   const match = /^window-(\d+)$/.exec(label);
-  return match ? Number.parseInt(match[1], 10) : 0;
+  return match ? Number.parseInt(match[1], 10) : -1;
 }
 
 /**
@@ -279,12 +284,17 @@ function installApiW3C(
     execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
       execute<R, A>(bridge, script, ...args),
     switchWindow: async (label: string) => {
-      const handles = await browser.getWindowHandles();
       const index = w3cWindowIndex(label);
+      if (index < 0) {
+        throw new Error(
+          `browser.electrobun.switchWindow("${label}"): unrecognised window label (expected "main" or "window-<n>").`,
+        );
+      }
+      const handles = await browser.getWindowHandles();
       const handle = handles[index];
       if (!handle) {
         throw new Error(
-          `browser.electrobun.switchWindow("${label}"): no window at index ${index} (open windows: ${handles.length})`,
+          `browser.electrobun.switchWindow("${label}"): no window at index ${index} (open windows: ${handles.length}).`,
         );
       }
       await browser.switchToWindow(handle);

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -10,7 +10,7 @@ import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
 import { ElectrobunMockStore } from './mockStore.js';
 import type { ElectrobunServiceOptions } from './types.js';
-import { installConsoleShim, WebDriverEvalBridge } from './webdriverEval.js';
+import { createWebDriverEvalBridge, installConsoleShim, type WebDriverEvalBridge } from './webdriverEval.js';
 
 const log = createLogger(SERVICE_NAME, 'service');
 
@@ -137,7 +137,7 @@ export default class ElectrobunWorkerService {
   /** Install `browser.electrobun.*` over the W3C session (Linux/WebKitGTK path). */
   private async attachW3CInstance(browser: WebdriverIO.Browser): Promise<void> {
     log.info('Installing browser.electrobun.* over W3C WebDriver (WebKitGTK)');
-    const evalBridge = new WebDriverEvalBridge(browser);
+    const evalBridge = createWebDriverEvalBridge(browser);
     const mockStore = new ElectrobunMockStore();
     this.mockStores.push(mockStore);
     // Frontend log capture without CDP console events: buffer console.* in-page, drain to the

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -186,14 +186,20 @@ export default class ElectrobunWorkerService {
     }
     for (const binary of this.w3cAppBinaries) {
       const bundleRoot = dirname(dirname(binary)); // <bundle>/bin/launcher -> <bundle>
-      // Safety: a too-generic pattern (e.g. '/', '/bin') would pkill unrelated processes. Only
-      // match against a specific, deep absolute path.
+      // Safety: a too-generic pattern (e.g. '/', '/bin') would match unrelated processes. Only
+      // match a specific, deep absolute path.
       if (!bundleRoot.startsWith('/') || bundleRoot.length < 8 || bundleRoot.split('/').filter(Boolean).length < 2) {
         log.warn(`Skipping WebKitGTK app reap: bundle path too generic to match safely (${bundleRoot})`);
         continue;
       }
+      // `pkill -f` treats the pattern as an unanchored regex, so (1) escape regex metacharacters
+      // in the path — an unescaped `.`/`+`/`(` etc. could mis-match — and (2) anchor to the
+      // command-line start with a trailing slash. The app's own processes (launcher, cottontail)
+      // have argv0 under `<bundle>/bin/…`, so `^<bundle>/` matches only them — never an unrelated
+      // process that merely mentions the path in a later argument, nor a sibling like `<bundle>-x`.
+      const pattern = `^${bundleRoot.replace(/[.^$*+?()[\]{}|\\]/g, '\\$&')}/`;
       try {
-        execFileSync('pkill', ['-9', '-f', bundleRoot], { stdio: 'ignore' });
+        execFileSync('pkill', ['-9', '-f', pattern], { stdio: 'ignore' });
         log.debug(`Reaped WebKitGTK app tree under ${bundleRoot}`);
       } catch {
         // pkill exits non-zero when nothing matched (already gone) — not an error.

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -10,6 +10,7 @@ import { triggerDeeplink } from './commands/triggerDeeplink.js';
 import { DEFAULT_REMOTE_DEBUGGING_PORT, SERVICE_NAME } from './constants.js';
 import { ElectrobunMockStore } from './mockStore.js';
 import type { ElectrobunServiceOptions } from './types.js';
+import { installConsoleShim, WebDriverEvalBridge } from './webdriverEval.js';
 
 const log = createLogger(SERVICE_NAME, 'service');
 
@@ -34,6 +35,8 @@ export default class ElectrobunWorkerService {
   private options: ElectrobunServiceOptions;
   private bridges: CdpBridge[] = [];
   private mockStores: ElectrobunMockStore[] = [];
+  /** Console-shim drains (Linux/W3C path only), flushed to the logger on teardown. */
+  private consoleDrains: Array<() => Promise<void>> = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
     const capOptions = (capabilities as { 'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions })[
@@ -71,6 +74,15 @@ export default class ElectrobunWorkerService {
   }
 
   private async attachInstance(browser: WebdriverIO.Browser, capabilities: unknown): Promise<void> {
+    // Linux/W3C (WebKitGTK): the WDIO session IS the WebKitWebDriver session — there is no CDP
+    // side-channel. The launcher marks this path with a `webkitgtk:browserOptions` capability.
+    // Drive the app over W3C `browser.execute` (via the eval adapter), reusing the CDP
+    // execute/mock machinery unchanged.
+    if ((capabilities as { 'webkitgtk:browserOptions'?: unknown } | undefined)?.['webkitgtk:browserOptions']) {
+      await this.attachW3CInstance(browser);
+      return;
+    }
+
     // The launcher sets debuggerAddress under `goog:chromeOptions` for the CEF/chromedriver
     // path and under `ms:edgeOptions` for the WebView2/Edge (msedgedriver) path — read both.
     const caps = capabilities as
@@ -122,6 +134,19 @@ export default class ElectrobunWorkerService {
     await syncWebDriverWindow(browser, bridge);
   }
 
+  /** Install `browser.electrobun.*` over the W3C session (Linux/WebKitGTK path). */
+  private async attachW3CInstance(browser: WebdriverIO.Browser): Promise<void> {
+    log.info('Installing browser.electrobun.* over W3C WebDriver (WebKitGTK)');
+    const evalBridge = new WebDriverEvalBridge(browser);
+    const mockStore = new ElectrobunMockStore();
+    this.mockStores.push(mockStore);
+    // Frontend log capture without CDP console events: buffer console.* in-page, drain to the
+    // logger on teardown. (Live frontend logs also surface via the driver's stdout.)
+    const drain = await installConsoleShim(browser);
+    this.consoleDrains.push(drain);
+    installApiW3C(browser, evalBridge, mockStore);
+  }
+
   async after(): Promise<void> {
     await this.closeBridges();
   }
@@ -131,6 +156,11 @@ export default class ElectrobunWorkerService {
   }
 
   private async closeBridges(): Promise<void> {
+    // Flush any buffered frontend console entries (W3C path) before tearing down the session.
+    for (const drain of this.consoleDrains) {
+      await drain().catch(() => {});
+    }
+    this.consoleDrains = [];
     for (const bridge of this.bridges) {
       await bridge.close().catch((error: Error) => {
         log.warn(`Failed to close CDP bridge: ${error.message}`);
@@ -221,4 +251,56 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: 
   };
   (browser as unknown as { electrobun: ElectrobunServiceAPI }).electrobun = electrobun;
   log.debug('Installed browser.electrobun.*');
+}
+
+/** Map a window label ('main', 'window-1', …) to a W3C window-handle index. */
+function w3cWindowIndex(label: string): number {
+  if (label === 'main') {
+    return 0;
+  }
+  const match = /^window-(\d+)$/.exec(label);
+  return match ? Number.parseInt(match[1], 10) : 0;
+}
+
+/**
+ * Install `browser.electrobun.*` for the W3C (WebKitGTK) transport. `execute` and `mock` reuse
+ * the CDP machinery unchanged via the `WebDriverEvalBridge` adapter (only its `send` is used);
+ * window switching goes through W3C window handles, and `triggerDeeplink` stays unsupported off
+ * macOS (the shared command already throws).
+ */
+function installApiW3C(
+  browser: WebdriverIO.Browser,
+  evalBridge: WebDriverEvalBridge,
+  mockStore: ElectrobunMockStore,
+): void {
+  // Only `send('Runtime.evaluate', …)` is exercised by execute/mock — the adapter satisfies it.
+  const bridge = evalBridge as unknown as CdpBridge;
+  const electrobun: ElectrobunServiceAPI = {
+    execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>
+      execute<R, A>(bridge, script, ...args),
+    switchWindow: async (label: string) => {
+      const handles = await browser.getWindowHandles();
+      const index = w3cWindowIndex(label);
+      const handle = handles[index];
+      if (!handle) {
+        throw new Error(
+          `browser.electrobun.switchWindow("${label}"): no window at index ${index} (open windows: ${handles.length})`,
+        );
+      }
+      await browser.switchToWindow(handle);
+    },
+    listWindows: async () => {
+      const handles = await browser.getWindowHandles();
+      return handles.map((_, i) => (i === 0 ? 'main' : `window-${i}`));
+    },
+    mock: (target: string) => mock(target, bridge, mockStore),
+    isMockFunction: ((targetOrFn: unknown) =>
+      isMockFunction(targetOrFn, mockStore)) as ElectrobunServiceAPI['isMockFunction'],
+    clearAllMocks: (prefix?: string) => clearAllMocks(mockStore, prefix),
+    resetAllMocks: (prefix?: string) => resetAllMocks(mockStore, prefix),
+    restoreAllMocks: (prefix?: string) => restoreAllMocks(mockStore, prefix),
+    triggerDeeplink: (url: string) => triggerDeeplink(url),
+  };
+  (browser as unknown as { electrobun: ElectrobunServiceAPI }).electrobun = electrobun;
+  log.debug('Installed browser.electrobun.* (W3C/WebKitGTK)');
 }

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from 'node:child_process';
+import { dirname } from 'node:path';
+
 import { MultiTargetCdpBridge as CdpBridge } from '@wdio/native-cdp-bridge';
 import type { ElectrobunServiceAPI } from '@wdio/native-types';
 import { createLogger } from '@wdio/native-utils';
@@ -37,6 +40,13 @@ export default class ElectrobunWorkerService {
   private mockStores: ElectrobunMockStore[] = [];
   /** Console-shim drains (Linux/W3C path only), flushed to the logger on teardown. */
   private consoleDrains: Array<() => Promise<void>> = [];
+  /**
+   * App launcher paths driven over W3C (WebKitGTK), captured to reap the app tree on teardown.
+   * WebKitWebDriver can't cleanly close the app's controlled webview, so `DELETE /session` hangs
+   * (~120s) unless the app is already gone — killing it in `after` (before WDIO's deleteSession)
+   * makes teardown return in milliseconds and reaps the process tree.
+   */
+  private w3cAppBinaries: string[] = [];
 
   constructor(options: ElectrobunServiceOptions, capabilities: unknown) {
     const capOptions = (capabilities as { 'wdio:electrobunServiceOptions'?: ElectrobunServiceOptions })[
@@ -78,7 +88,13 @@ export default class ElectrobunWorkerService {
     // side-channel. The launcher marks this path with a `webkitgtk:browserOptions` capability.
     // Drive the app over W3C `browser.execute` (via the eval adapter), reusing the CDP
     // execute/mock machinery unchanged.
-    if ((capabilities as { 'webkitgtk:browserOptions'?: unknown } | undefined)?.['webkitgtk:browserOptions']) {
+    const w3cOptions = (capabilities as { 'webkitgtk:browserOptions'?: { binary?: string } } | undefined)?.[
+      'webkitgtk:browserOptions'
+    ];
+    if (w3cOptions) {
+      if (w3cOptions.binary) {
+        this.w3cAppBinaries.push(w3cOptions.binary);
+      }
       await this.attachW3CInstance(browser);
       return;
     }
@@ -148,11 +164,42 @@ export default class ElectrobunWorkerService {
   }
 
   async after(): Promise<void> {
+    // Drain the console shim (needs the session alive) and close bridges FIRST, then reap the app
+    // — `after` runs before WDIO's deleteSession, so reaping here makes that DELETE return in ms.
     await this.closeBridges();
+    this.reapW3CApps();
   }
 
   async afterSession(): Promise<void> {
     await this.closeBridges();
+    this.reapW3CApps();
+  }
+
+  /**
+   * Kill the WebKitGTK app tree(s) driven this session (Linux/W3C only). WebKitWebDriver can't
+   * cleanly close the app's controlled webview, so `DELETE /session` otherwise hangs ~120s.
+   * Matches only the app's own bundle path; on Linux the WebKitGTK path is single-instance.
+   */
+  private reapW3CApps(): void {
+    if (process.platform !== 'linux' || this.w3cAppBinaries.length === 0) {
+      return;
+    }
+    for (const binary of this.w3cAppBinaries) {
+      const bundleRoot = dirname(dirname(binary)); // <bundle>/bin/launcher -> <bundle>
+      // Safety: a too-generic pattern (e.g. '/', '/bin') would pkill unrelated processes. Only
+      // match against a specific, deep absolute path.
+      if (!bundleRoot.startsWith('/') || bundleRoot.length < 8 || bundleRoot.split('/').filter(Boolean).length < 2) {
+        log.warn(`Skipping WebKitGTK app reap: bundle path too generic to match safely (${bundleRoot})`);
+        continue;
+      }
+      try {
+        execFileSync('pkill', ['-9', '-f', bundleRoot], { stdio: 'ignore' });
+        log.debug(`Reaped WebKitGTK app tree under ${bundleRoot}`);
+      } catch {
+        // pkill exits non-zero when nothing matched (already gone) — not an error.
+      }
+    }
+    this.w3cAppBinaries = [];
   }
 
   private async closeBridges(): Promise<void> {

--- a/packages/electrobun-service/src/service.ts
+++ b/packages/electrobun-service/src/service.ts
@@ -152,8 +152,8 @@ export default class ElectrobunWorkerService {
   }
 
   async after(): Promise<void> {
-    // `after` runs before WDIO's deleteSession, so reaping the app here makes that DELETE return
-    // in ms (not ~120s). closeBridges() first — the console-shim drain needs the session alive.
+    // `after` runs before WDIO's deleteSession, so reaping the app here lets that DELETE return fast.
+    // closeBridges() first — the console-shim drain needs the session still alive.
     await this.closeBridges();
     this.reapW3CApps();
   }
@@ -164,9 +164,8 @@ export default class ElectrobunWorkerService {
   }
 
   /**
-   * Kill the WebKitGTK app tree(s) driven this session (Linux/W3C only). WebKitWebDriver can't
-   * cleanly close the app's controlled webview, so `DELETE /session` otherwise hangs ~120s.
-   * Matches only the app's own bundle path; on Linux the WebKitGTK path is single-instance.
+   * Kill the WebKitGTK app tree(s) driven this session (Linux/W3C only). Without this,
+   * WebKitWebDriver can't cleanly close the app's controlled webview and `DELETE /session` hangs ~120s.
    */
   private reapW3CApps(): void {
     if (process.platform !== 'linux' || this.w3cAppBinaries.length === 0) {
@@ -174,23 +173,21 @@ export default class ElectrobunWorkerService {
     }
     for (const binary of this.w3cAppBinaries) {
       const bundleRoot = dirname(dirname(binary)); // <bundle>/bin/launcher -> <bundle>
-      // Safety: a too-generic pattern (e.g. '/', '/bin') would match unrelated processes. Only
-      // match a specific, deep absolute path.
+      // Safety: skip a too-generic bundle path (e.g. `/`, `/bin`) that could match unrelated processes.
       if (!bundleRoot.startsWith('/') || bundleRoot.length < 8 || bundleRoot.split('/').filter(Boolean).length < 2) {
         log.warn(`Skipping WebKitGTK app reap: bundle path too generic to match safely (${bundleRoot})`);
         continue;
       }
-      // `pkill -f` treats the pattern as an unanchored regex, so (1) escape regex metacharacters
-      // in the path — an unescaped `.`/`+`/`(` etc. could mis-match — and (2) anchor to the
-      // command-line start with a trailing slash. The app's own processes (launcher, cottontail)
-      // have argv0 under `<bundle>/bin/…`, so `^<bundle>/` matches only them — never an unrelated
-      // process that merely mentions the path in a later argument, nor a sibling like `<bundle>-x`.
+      // `pkill -f` matches the pattern as an unanchored regex over the whole command line, so escape
+      // the path's regex metacharacters and anchor with `^…/`. The trailing slash pins the match to
+      // the app's own processes (argv0 under `<bundle>/bin/…`) — not a process that mentions the path
+      // in a later argument, nor a `<bundle>-x` sibling.
       const pattern = `^${bundleRoot.replace(/[.^$*+?()[\]{}|\\]/g, '\\$&')}/`;
       try {
         execFileSync('pkill', ['-9', '-f', pattern], { stdio: 'ignore' });
         log.debug(`Reaped WebKitGTK app tree under ${bundleRoot}`);
       } catch {
-        // pkill exits non-zero when nothing matched (already gone) — not an error.
+        // pkill exits non-zero when nothing matched — not an error.
       }
     }
     this.w3cAppBinaries = [];
@@ -293,15 +290,12 @@ function installApi(browser: WebdriverIO.Browser, bridge: CdpBridge, mockStore: 
   log.debug('Installed browser.electrobun.*');
 }
 
-/**
- * -1 for an unrecognised label so `switchWindow` rejects instead of silently targeting window 0.
- * W3C `getWindowHandles` order is unspecified, so the index→window mapping is best-effort.
- */
 function w3cWindowIndex(label: string): number {
   if (label === 'main') {
     return 0;
   }
   const match = /^window-(\d+)$/.exec(label);
+  // -1 (not 0) for an unrecognised label so `switchWindow` rejects instead of targeting window 0.
   return match ? Number.parseInt(match[1], 10) : -1;
 }
 
@@ -310,7 +304,7 @@ function installApiW3C(
   evalBridge: WebDriverEvalBridge,
   mockStore: ElectrobunMockStore,
 ): void {
-  // Only `send('Runtime.evaluate', …)` is exercised by execute/mock — the adapter satisfies it.
+  // Safe cast: execute/mock only call `send('Runtime.evaluate', …)`, which WebDriverEvalBridge implements.
   const bridge = evalBridge as unknown as CdpBridge;
   const electrobun: ElectrobunServiceAPI = {
     execute: <R, A extends unknown[]>(script: Parameters<typeof execute<R, A>>[1], ...args: A): Promise<R> =>

--- a/packages/electrobun-service/src/transport.ts
+++ b/packages/electrobun-service/src/transport.ts
@@ -1,5 +1,5 @@
 // Transport by platform + renderer. macOS → CEF (WKWebView exposes no CDP); Windows → native
-// WebView2 (Chromium/CDP); Linux → native WebKitGTK over W3C WebDriver (electrobun 2.0.1, #467).
+// WebView2 (Chromium/CDP); Linux → native WebKitGTK over W3C WebDriver.
 // A CEF build serves no `/json` off macOS, so CEF-on-Windows/Linux is unsupported.
 
 import type { ResolvedElectrobunApp } from './electrobunConfig.js';

--- a/packages/electrobun-service/src/transport.ts
+++ b/packages/electrobun-service/src/transport.ts
@@ -1,39 +1,55 @@
-// Which CDP transport drives a native-renderer Electrobun app, by platform + renderer.
+// Which transport drives a native-renderer Electrobun app, by platform + renderer.
 //
-// Electrobun's renderer is per-OS: macOS uses CEF (the only macOS renderer that serves
-// a `/json` CDP endpoint — WKWebView has none), while the default `'native'` renderer maps
-// to the system webview — WebView2 (Chromium) on Windows, which serves CDP once launched
-// with `--remote-debugging-port`. Linux's WebKitGTK has no CDP/automation surface yet, and
-// CEF-on-Windows/Linux serves no `/json`. This keeps the platform/renderer decision in one
-// tested place for the launcher and the spawn path.
+// Electrobun's renderer is per-OS. Two transport families:
+//  - **CDP-attach** (Chromium renderers): macOS uses CEF (the only macOS renderer that serves
+//    a `/json` CDP endpoint — WKWebView has none); Windows uses the native WebView2 (Chromium)
+//    renderer, which serves CDP once launched with `--remote-debugging-port`.
+//  - **W3C WebDriver** (WebKit renderer): Linux's native WebKitGTK renderer speaks W3C
+//    WebDriver via `WebKitWebDriver` once the app opts into automation — shipped upstream in
+//    electrobun 2.0.1 (#467). The driver launches the app; there is no CDP.
+//
+// A CEF build serves no `/json` off macOS, so CEF-on-Windows/Linux is unsupported. This keeps
+// the platform/renderer decision in one tested place for the launcher and the spawn path.
 
 import type { ResolvedElectrobunApp } from './electrobunConfig.js';
 
-/** CDP transport for driving a native-renderer Electrobun app. */
-export type ElectrobunTransport = 'cef' | 'webview2';
+/**
+ * Transport for driving a native-renderer Electrobun app.
+ * - `'cef'` / `'webview2'` → CDP-attach (the service spawns the app; a Chromedriver attaches).
+ * - `'webkitgtk'` → W3C WebDriver (`WebKitWebDriver` spawns the app and the worker drives it
+ *   over classic WebDriver; no CDP bridge).
+ */
+export type ElectrobunTransport = 'cef' | 'webview2' | 'webkitgtk';
 
 /**
- * Decide the CDP transport for a resolved app on a platform, or `undefined` when the
- * platform/renderer has no usable CDP surface (caller fails fast).
+ * Decide the transport for a resolved app on a platform, or `undefined` when the
+ * platform/renderer has no usable automation surface (caller fails fast).
  *
  * - macOS → `'cef'`.
  * - Windows → `'webview2'`, UNLESS the bundle is explicitly CEF (CEF-on-Windows serves no
  *   `/json`), which yields `undefined`.
- * - Linux (and anything else) → `undefined`.
+ * - Linux → `'webkitgtk'` for the native renderer, UNLESS the bundle is explicitly CEF
+ *   (CEF-on-Linux serves no `/json`), which yields `undefined`.
+ * - Anything else → `undefined`.
  */
 export function resolveTransport(
   app: ResolvedElectrobunApp,
   platform: NodeJS.Platform = process.platform,
 ): ElectrobunTransport | undefined {
+  // `readRenderer` records build.json's renderer as exactly 'cef' or 'native' (lower-cased),
+  // so match the whole value rather than a substring.
   const renderer = app.renderer ?? '';
   if (platform === 'darwin') {
     return 'cef';
   }
   if (platform === 'win32') {
-    // Windows drives the native WebView2 renderer; an explicit CEF build is unsupported there
-    // (it serves no /json). `readRenderer` records build.json's renderer as exactly 'cef' or
-    // 'native' (lower-cased), so match the whole value rather than a substring.
+    // Windows drives the native WebView2 renderer; an explicit CEF build is unsupported there.
     return renderer === 'cef' ? undefined : 'webview2';
+  }
+  if (platform === 'linux') {
+    // Linux drives the native WebKitGTK renderer over W3C WebDriver; an explicit CEF build is
+    // unsupported there (serves no /json).
+    return renderer === 'cef' ? undefined : 'webkitgtk';
   }
   return undefined;
 }

--- a/packages/electrobun-service/src/transport.ts
+++ b/packages/electrobun-service/src/transport.ts
@@ -22,15 +22,9 @@ import type { ResolvedElectrobunApp } from './electrobunConfig.js';
 export type ElectrobunTransport = 'cef' | 'webview2' | 'webkitgtk';
 
 /**
- * Decide the transport for a resolved app on a platform, or `undefined` when the
- * platform/renderer has no usable automation surface (caller fails fast).
- *
- * - macOS → `'cef'`.
- * - Windows → `'webview2'`, UNLESS the bundle is explicitly CEF (CEF-on-Windows serves no
- *   `/json`), which yields `undefined`.
- * - Linux → `'webkitgtk'` for the native renderer, UNLESS the bundle is explicitly CEF
- *   (CEF-on-Linux serves no `/json`), which yields `undefined`.
- * - Anything else → `undefined`.
+ * Decide the transport for a resolved app on a platform, or `undefined` when there's no usable
+ * automation surface — an explicit CEF build off macOS, or a non-desktop platform — so the caller
+ * fails fast.
  */
 export function resolveTransport(
   app: ResolvedElectrobunApp,
@@ -43,12 +37,9 @@ export function resolveTransport(
     return 'cef';
   }
   if (platform === 'win32') {
-    // Windows drives the native WebView2 renderer; an explicit CEF build is unsupported there.
     return renderer === 'cef' ? undefined : 'webview2';
   }
   if (platform === 'linux') {
-    // Linux drives the native WebKitGTK renderer over W3C WebDriver; an explicit CEF build is
-    // unsupported there (serves no /json).
     return renderer === 'cef' ? undefined : 'webkitgtk';
   }
   return undefined;

--- a/packages/electrobun-service/src/transport.ts
+++ b/packages/electrobun-service/src/transport.ts
@@ -1,37 +1,15 @@
-// Which transport drives a native-renderer Electrobun app, by platform + renderer.
-//
-// Electrobun's renderer is per-OS. Two transport families:
-//  - **CDP-attach** (Chromium renderers): macOS uses CEF (the only macOS renderer that serves
-//    a `/json` CDP endpoint — WKWebView has none); Windows uses the native WebView2 (Chromium)
-//    renderer, which serves CDP once launched with `--remote-debugging-port`.
-//  - **W3C WebDriver** (WebKit renderer): Linux's native WebKitGTK renderer speaks W3C
-//    WebDriver via `WebKitWebDriver` once the app opts into automation — shipped upstream in
-//    electrobun 2.0.1 (#467). The driver launches the app; there is no CDP.
-//
-// A CEF build serves no `/json` off macOS, so CEF-on-Windows/Linux is unsupported. This keeps
-// the platform/renderer decision in one tested place for the launcher and the spawn path.
+// Transport by platform + renderer. macOS → CEF (WKWebView exposes no CDP); Windows → native
+// WebView2 (Chromium/CDP); Linux → native WebKitGTK over W3C WebDriver (electrobun 2.0.1, #467).
+// A CEF build serves no `/json` off macOS, so CEF-on-Windows/Linux is unsupported.
 
 import type { ResolvedElectrobunApp } from './electrobunConfig.js';
 
-/**
- * Transport for driving a native-renderer Electrobun app.
- * - `'cef'` / `'webview2'` → CDP-attach (the service spawns the app; a Chromedriver attaches).
- * - `'webkitgtk'` → W3C WebDriver (`WebKitWebDriver` spawns the app and the worker drives it
- *   over classic WebDriver; no CDP bridge).
- */
 export type ElectrobunTransport = 'cef' | 'webview2' | 'webkitgtk';
 
-/**
- * Decide the transport for a resolved app on a platform, or `undefined` when there's no usable
- * automation surface — an explicit CEF build off macOS, or a non-desktop platform — so the caller
- * fails fast.
- */
 export function resolveTransport(
   app: ResolvedElectrobunApp,
   platform: NodeJS.Platform = process.platform,
 ): ElectrobunTransport | undefined {
-  // `readRenderer` records build.json's renderer as exactly 'cef' or 'native' (lower-cased),
-  // so match the whole value rather than a substring.
   const renderer = app.renderer ?? '';
   if (platform === 'darwin') {
     return 'cef';

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -5,11 +5,11 @@
 // exposes the one method those code paths use (`send('Runtime.evaluate', …)`), so the entire
 // execute + mock + inner-recorder machinery is reused verbatim over W3C.
 //
-// IMPORTANT: it posts to `/execute/async` DIRECTLY (raw HTTP), not via WDIO's
-// `browser.executeAsync`/`executeAsyncScript`. WDIO wraps the script and turns a page-level
-// throw into a WebDriverError that surfaces the JSC stack (which omits the message), breaking
-// error propagation. The raw endpoint honours our in-page `try/catch → done({ok,error})`
-// protocol and returns a clean message — verified against WebKitWebDriver directly.
+// IMPORTANT: posts to `/execute/async` DIRECTLY (raw HTTP), not via WDIO's
+// `browser.executeAsync`/`executeAsyncScript`. Those turn a page-level throw into a WebDriverError
+// whose message is lost on WebKit — the JSC error stack carries no message — so the real error
+// never reaches us. Instead the injected script never throws: it catches and hands back
+// `{ ok, error }` via `done` (see `buildScript`), which we read straight off the raw response.
 
 import http from 'node:http';
 import https from 'node:https';
@@ -20,7 +20,6 @@ import { SERVICE_NAME } from './constants.js';
 
 const log = createLogger(SERVICE_NAME, 'bridge');
 
-/** Outcome our in-page script resolves `done` with (never a raw throw — WebKit reports those). */
 type EvalOutcome = { ok: true; value: unknown; undef?: boolean } | { ok: false; error: string };
 
 export type ExecuteAsyncPoster = (script: string) => Promise<{ value: unknown }>;

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -23,7 +23,7 @@ const log = createLogger(SERVICE_NAME, 'bridge');
 /** Outcome our in-page script resolves `done` with (never a raw throw — WebKit reports those). */
 type EvalOutcome = { ok: true; value: unknown; undef?: boolean } | { ok: false; error: string };
 
-/** Posts a script to `/execute/async` and returns the parsed W3C response `{ value }`. */
+/** Runs an in-page script over `/execute/async`; injected so tests can supply a fake. */
 export type ExecuteAsyncPoster = (script: string) => Promise<{ value: unknown }>;
 
 /** The minimal CDP response shape `evaluateInActiveTarget` reads. */
@@ -111,16 +111,15 @@ export function createWebDriverEvalBridge(browser: WebdriverIO.Browser): WebDriv
   const hostname = options.hostname ?? '127.0.0.1';
   const port = options.port ?? 4444;
   // The launcher connects WDIO to WebKitWebDriver at the session root ('/'), so the base is
-  // protocol://host:port. sessionId is the live W3C session.
+  // just protocol://host:port.
   const baseUrl = `${protocol}://${hostname}:${port}`;
   return new WebDriverEvalBridge(httpExecuteAsyncPoster(baseUrl, browser.sessionId));
 }
 
 /**
- * Install a `console.*` shim in the app's page that buffers entries on
- * `window.__WDIO_ELECTROBUN_LOGS__`, and return a reader that drains the buffer and forwards
- * entries to the WDIO logger. Frontend log capture without CDP console events. These scripts
- * never throw, so plain `browser.execute` is fine here (unlike the eval channel above).
+ * Frontend log capture without CDP console events: a `console.*` shim buffers entries in-page,
+ * and the returned reader drains them to the WDIO logger. These scripts never throw, so plain
+ * `browser.execute` is fine here (unlike the eval channel above).
  *
  * NOTE: the shim is per-document — a full-page navigation resets `window`, so entries logged
  * before a navigation are lost from the buffer. Cross-navigation frontend logs still surface via

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -1,11 +1,18 @@
 // W3C-WebDriver eval channel for the Linux WebKitGTK transport.
 //
-// The CDP path runs `execute`/`mock` scripts through the CdpBridge's
-// `Runtime.evaluate`. On WebKitGTK there is no CDP — the worker's WDIO session IS the
-// WebKitWebDriver session, so scripts run over W3C `/execute/async`. `WebDriverEvalBridge`
-// exposes the one method those code paths use (`send('Runtime.evaluate', …)`), backed by
-// `browser.executeAsync`, so the entire execute + mock + inner-recorder machinery is reused
-// verbatim over W3C — no separate implementation, no divergence from the CDP surface.
+// The CDP path runs `execute`/`mock` scripts through the CdpBridge's `Runtime.evaluate`. On
+// WebKitGTK there is no CDP — scripts run over W3C `/execute/async`. `WebDriverEvalBridge`
+// exposes the one method those code paths use (`send('Runtime.evaluate', …)`), so the entire
+// execute + mock + inner-recorder machinery is reused verbatim over W3C.
+//
+// IMPORTANT: it posts to `/execute/async` DIRECTLY (raw HTTP), not via WDIO's
+// `browser.executeAsync`/`executeAsyncScript`. WDIO wraps the script and turns a page-level
+// throw into a WebDriverError that surfaces the JSC stack (which omits the message), breaking
+// error propagation. The raw endpoint honours our in-page `try/catch → done({ok,error})`
+// protocol and returns a clean message — verified against WebKitWebDriver directly.
+
+import http from 'node:http';
+import https from 'node:https';
 
 import { createLogger } from '@wdio/native-utils';
 
@@ -13,27 +20,11 @@ import { SERVICE_NAME } from './constants.js';
 
 const log = createLogger(SERVICE_NAME, 'bridge');
 
-/** Outcome of evaluating an expression in the page (never throws for a page-level JS error). */
+/** Outcome our in-page script resolves `done` with (never a raw throw — WebKit reports those). */
 type EvalOutcome = { ok: true; value: unknown; undef?: boolean } | { ok: false; error: string };
 
-/**
- * Evaluate an expression string in the app's realm over W3C `/execute/async` and resolve its
- * (awaited) value, or an error string for a page-level rejection. The expression is inlined
- * into the async script BODY (not `eval`/`Function`), so it works under a page CSP that forbids
- * `unsafe-eval`. `awaitPromise` semantics match CDP: the value is unwrapped from a Promise.
- *
- * `undef` flags a genuine `undefined` result so the caller can distinguish it from `null` —
- * WebDriver serialises a bare `undefined` as `null`, unlike CDP's returnByValue.
- */
-async function runInPage(browser: WebdriverIO.Browser, expression: string): Promise<EvalOutcome> {
-  // The W3C async script receives an injected callback as its last argument.
-  const body =
-    'var done = arguments[arguments.length - 1];' +
-    `Promise.resolve().then(function () { return (${expression}); }).then(` +
-    'function (v) { done({ ok: true, value: v, undef: v === undefined }); },' +
-    'function (e) { done({ ok: false, error: String((e && e.stack) || e) }); });';
-  return (await browser.executeAsync(body)) as EvalOutcome;
-}
+/** Posts a script to `/execute/async` and returns the parsed W3C response `{ value }`. */
+export type ExecuteAsyncPoster = (script: string) => Promise<{ value: unknown }>;
 
 /** The minimal CDP response shape `evaluateInActiveTarget` reads. */
 interface RuntimeEvaluateResponse {
@@ -42,39 +33,99 @@ interface RuntimeEvaluateResponse {
 }
 
 /**
- * A CdpBridge-shaped adapter that satisfies the single method `execute`/`createMock` use
- * (`send('Runtime.evaluate', { expression })`). Passed where a `CdpBridge` is expected so the
- * CDP execute + mock code drives the app over W3C WebDriver unchanged.
+ * Wrap an expression so it ALWAYS calls `done` with an outcome — never lets an exception reach
+ * the automation context (WebKit reports any throw as a command error). `undef` flags a genuine
+ * `undefined` (WebDriver would otherwise serialise it as `null`). The callback is the W3C
+ * `/execute/async` injected last argument.
+ */
+function buildScript(expression: string): string {
+  return (
+    'var done = arguments[arguments.length - 1];' +
+    '(async function () {' +
+    `  try { var v = await (${expression}); done({ ok: true, value: v, undef: v === undefined }); }` +
+    '  catch (e) { done({ ok: false, error: e && e.message ? String(e.message) : String(e) }); }' +
+    '})().catch(function (e) { done({ ok: false, error: e && e.message ? String(e.message) : String(e) }); });'
+  );
+}
+
+/** Build a raw `/execute/async` poster from the session's connection details. */
+export function httpExecuteAsyncPoster(baseUrl: string, sessionId: string): ExecuteAsyncPoster {
+  const transport = baseUrl.startsWith('https') ? https : http;
+  return (script) =>
+    new Promise((resolve, reject) => {
+      const url = new URL(`session/${sessionId}/execute/async`, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+      const data = Buffer.from(JSON.stringify({ script, args: [] }));
+      const request = transport.request(
+        url,
+        { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': data.length } },
+        (res) => {
+          let buf = '';
+          res.on('data', (chunk) => (buf += chunk));
+          res.on('end', () => {
+            try {
+              resolve(JSON.parse(buf || '{}') as { value: unknown });
+            } catch (error) {
+              reject(new Error(`Invalid /execute/async response: ${(error as Error).message}`));
+            }
+          });
+        },
+      );
+      request.on('error', reject);
+      request.setTimeout(120_000, () => request.destroy(new Error('execute/async request timed out')));
+      request.write(data);
+      request.end();
+    });
+}
+
+/**
+ * A CdpBridge-shaped adapter satisfying the single method `execute`/`createMock` use
+ * (`send('Runtime.evaluate', { expression })`), backed by a raw `/execute/async` poster.
  */
 export class WebDriverEvalBridge {
-  constructor(private readonly browser: WebdriverIO.Browser) {}
+  constructor(private readonly post: ExecuteAsyncPoster) {}
 
   async send(method: string, params: { expression: string }): Promise<RuntimeEvaluateResponse> {
     if (method !== 'Runtime.evaluate') {
-      // execute/mock only ever call Runtime.evaluate; anything else is a wiring bug.
       throw new Error(`WebDriverEvalBridge supports only Runtime.evaluate over W3C, received: ${method}`);
     }
-    const outcome = await runInPage(this.browser, params.expression);
-    if (outcome.ok) {
-      // Preserve a genuine `undefined` result (WebDriver would otherwise surface it as `null`),
-      // matching the CDP path so the execute surface is convergent across transports.
-      return { result: { value: outcome.undef ? undefined : outcome.value } };
+    const response = await this.post(buildScript(params.expression));
+    const value = response?.value;
+    if (value && typeof value === 'object' && 'ok' in value) {
+      const outcome = value as EvalOutcome;
+      if (outcome.ok) {
+        // Preserve a genuine `undefined` (WebDriver would surface it as `null`) — matches CDP.
+        return { result: { value: outcome.undef ? undefined : outcome.value } };
+      }
+      return { exceptionDetails: { text: outcome.error, exception: { description: outcome.error } } };
     }
-    // Page-level JS error → mirror CDP's exceptionDetails so the caller wraps it with context.
-    return { exceptionDetails: { text: outcome.error, exception: { description: outcome.error } } };
+    // A W3C error response (non-200): a sync/parse error not caught by our in-page try/catch.
+    const message = (value as { message?: string } | undefined)?.message ?? 'unknown W3C script error';
+    return { exceptionDetails: { text: message, exception: { description: message } } };
   }
+}
+
+/** Build a `WebDriverEvalBridge` from a live WDIO session (its connection host/port + sessionId). */
+export function createWebDriverEvalBridge(browser: WebdriverIO.Browser): WebDriverEvalBridge {
+  const options = browser.options as { protocol?: string; hostname?: string; port?: number; path?: string };
+  const protocol = options.protocol ?? 'http';
+  const hostname = options.hostname ?? '127.0.0.1';
+  const port = options.port ?? 4444;
+  // The launcher connects WDIO to WebKitWebDriver at the session root ('/'), so the base is
+  // protocol://host:port. sessionId is the live W3C session.
+  const baseUrl = `${protocol}://${hostname}:${port}`;
+  return new WebDriverEvalBridge(httpExecuteAsyncPoster(baseUrl, browser.sessionId));
 }
 
 /**
  * Install a `console.*` shim in the app's page that buffers entries on
  * `window.__WDIO_ELECTROBUN_LOGS__`, and return a reader that drains the buffer and forwards
- * entries to the WDIO logger. Frontend log capture without CDP console events (the WebKitGTK
- * path has none). Best-effort: injection/read failures are logged, not fatal.
+ * entries to the WDIO logger. Frontend log capture without CDP console events. These scripts
+ * never throw, so plain `browser.execute` is fine here (unlike the eval channel above).
  *
  * NOTE: the shim is per-document — a full-page navigation resets `window`, so entries logged
- * before a navigation are lost from the buffer. Cross-navigation frontend logs still surface
- * via the driver's stdout (electrobun forwards `console.*` there), which the launcher pipes to
- * the logger; this shim is the structured, in-page supplement to that live stream.
+ * before a navigation are lost from the buffer. Cross-navigation frontend logs still surface via
+ * the driver's stdout (electrobun forwards `console.*` there), which the launcher pipes to the
+ * logger; this shim is the structured, in-page supplement to that live stream.
  */
 export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<() => Promise<void>> {
   const installScript =

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -1,0 +1,106 @@
+// W3C-WebDriver eval channel for the Linux WebKitGTK transport.
+//
+// The CDP path runs `execute`/`mock` scripts through the CdpBridge's
+// `Runtime.evaluate`. On WebKitGTK there is no CDP — the worker's WDIO session IS the
+// WebKitWebDriver session, so scripts run over W3C `/execute/async`. `WebDriverEvalBridge`
+// exposes the one method those code paths use (`send('Runtime.evaluate', …)`), backed by
+// `browser.executeAsync`, so the entire execute + mock + inner-recorder machinery is reused
+// verbatim over W3C — no separate implementation, no divergence from the CDP surface.
+
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+
+const log = createLogger(SERVICE_NAME, 'bridge');
+
+/** Outcome of evaluating an expression in the page (never throws for a page-level JS error). */
+type EvalOutcome = { ok: true; value: unknown } | { ok: false; error: string };
+
+/**
+ * Evaluate an expression string in the app's realm over W3C `/execute/async` and resolve its
+ * (awaited) value, or an error string for a page-level rejection. The expression is inlined
+ * into the async script BODY (not `eval`/`Function`), so it works under a page CSP that forbids
+ * `unsafe-eval`. `awaitPromise` semantics match CDP: the value is unwrapped from a Promise.
+ */
+async function runInPage(browser: WebdriverIO.Browser, expression: string): Promise<EvalOutcome> {
+  // The W3C async script receives an injected callback as its last argument.
+  const body =
+    'var done = arguments[arguments.length - 1];' +
+    `Promise.resolve().then(function () { return (${expression}); }).then(` +
+    'function (v) { done({ ok: true, value: v }); },' +
+    'function (e) { done({ ok: false, error: String((e && e.stack) || e) }); });';
+  return (await browser.executeAsync(body)) as EvalOutcome;
+}
+
+/** The minimal CDP response shape `evaluateInActiveTarget` reads. */
+interface RuntimeEvaluateResponse {
+  result?: { value?: unknown };
+  exceptionDetails?: { text?: string; exception?: { description?: string } };
+}
+
+/**
+ * A CdpBridge-shaped adapter that satisfies the single method `execute`/`createMock` use
+ * (`send('Runtime.evaluate', { expression })`). Passed where a `CdpBridge` is expected so the
+ * CDP execute + mock code drives the app over W3C WebDriver unchanged.
+ */
+export class WebDriverEvalBridge {
+  constructor(private readonly browser: WebdriverIO.Browser) {}
+
+  async send(method: string, params: { expression: string }): Promise<RuntimeEvaluateResponse> {
+    if (method !== 'Runtime.evaluate') {
+      // execute/mock only ever call Runtime.evaluate; anything else is a wiring bug.
+      throw new Error(`WebDriverEvalBridge supports only Runtime.evaluate over W3C, received: ${method}`);
+    }
+    const outcome = await runInPage(this.browser, params.expression);
+    if (outcome.ok) {
+      return { result: { value: outcome.value } };
+    }
+    // Page-level JS error → mirror CDP's exceptionDetails so the caller wraps it with context.
+    return { exceptionDetails: { text: outcome.error, exception: { description: outcome.error } } };
+  }
+}
+
+/**
+ * Install a `console.*` shim in the app's page that buffers entries on
+ * `window.__WDIO_ELECTROBUN_LOGS__`, and return a reader that drains the buffer and forwards
+ * entries to the WDIO logger. Frontend log capture without CDP console events (the WebKitGTK
+ * path has none). Best-effort: injection/read failures are logged, not fatal.
+ */
+export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<() => Promise<void>> {
+  const installScript =
+    '(function () {' +
+    '  if (window.__WDIO_ELECTROBUN_LOGS_INSTALLED__) { return true; }' +
+    '  window.__WDIO_ELECTROBUN_LOGS_INSTALLED__ = true;' +
+    '  window.__WDIO_ELECTROBUN_LOGS__ = [];' +
+    "  ['log','info','warn','error','debug'].forEach(function (level) {" +
+    '    var original = console[level] ? console[level].bind(console) : function () {};' +
+    '    console[level] = function () {' +
+    '      try {' +
+    '        window.__WDIO_ELECTROBUN_LOGS__.push({ level: level, args: Array.prototype.map.call(arguments, String) });' +
+    '      } catch (e) { /* ignore */ }' +
+    '      original.apply(console, arguments);' +
+    '    };' +
+    '  });' +
+    '  return true;' +
+    '})()';
+  try {
+    await browser.execute(installScript);
+  } catch (error) {
+    log.warn(`Could not install the console shim: ${(error as Error).message}`);
+  }
+
+  return async function drain(): Promise<void> {
+    try {
+      const entries = (await browser.execute(
+        'var l = window.__WDIO_ELECTROBUN_LOGS__ || []; window.__WDIO_ELECTROBUN_LOGS__ = []; return l;',
+      )) as unknown as Array<{ level: string; args: string[] }>;
+      for (const entry of entries ?? []) {
+        const line = `[webview] ${entry.args.join(' ')}`;
+        const level = entry.level === 'debug' ? 'debug' : entry.level === 'error' ? 'error' : 'info';
+        (log as unknown as Record<string, (msg: string) => void>)[level]?.(line);
+      }
+    } catch (error) {
+      log.debug(`Console shim drain failed: ${(error as Error).message}`);
+    }
+  };
+}

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -23,20 +23,17 @@ const log = createLogger(SERVICE_NAME, 'bridge');
 /** Outcome our in-page script resolves `done` with (never a raw throw — WebKit reports those). */
 type EvalOutcome = { ok: true; value: unknown; undef?: boolean } | { ok: false; error: string };
 
-/** Runs an in-page script over `/execute/async`; injected so tests can supply a fake. */
 export type ExecuteAsyncPoster = (script: string) => Promise<{ value: unknown }>;
 
-/** The minimal CDP response shape `evaluateInActiveTarget` reads. */
 interface RuntimeEvaluateResponse {
   result?: { value?: unknown };
   exceptionDetails?: { text?: string; exception?: { description?: string } };
 }
 
 /**
- * Wrap an expression so it ALWAYS calls `done` with an outcome — never lets an exception reach
- * the automation context (WebKit reports any throw as a command error). `undef` flags a genuine
- * `undefined` (WebDriver would otherwise serialise it as `null`). The callback is the W3C
- * `/execute/async` injected last argument.
+ * Wrap an expression so it ALWAYS calls `done` with an outcome — never lets an exception reach the
+ * automation context (WebKit reports any throw as a command error). `undef` flags a genuine
+ * `undefined` (WebDriver would otherwise serialise it as `null`).
  */
 function buildScript(expression: string): string {
   return (
@@ -48,7 +45,6 @@ function buildScript(expression: string): string {
   );
 }
 
-/** Build a raw `/execute/async` poster from the session's connection details. */
 export function httpExecuteAsyncPoster(baseUrl: string, sessionId: string): ExecuteAsyncPoster {
   const transport = baseUrl.startsWith('https') ? https : http;
   return (script) =>
@@ -77,10 +73,6 @@ export function httpExecuteAsyncPoster(baseUrl: string, sessionId: string): Exec
     });
 }
 
-/**
- * A CdpBridge-shaped adapter satisfying the single method `execute`/`createMock` use
- * (`send('Runtime.evaluate', { expression })`), backed by a raw `/execute/async` poster.
- */
 export class WebDriverEvalBridge {
   constructor(private readonly post: ExecuteAsyncPoster) {}
 
@@ -93,7 +85,6 @@ export class WebDriverEvalBridge {
     if (value && typeof value === 'object' && 'ok' in value) {
       const outcome = value as EvalOutcome;
       if (outcome.ok) {
-        // Preserve a genuine `undefined` (WebDriver would surface it as `null`) — matches CDP.
         return { result: { value: outcome.undef ? undefined : outcome.value } };
       }
       return { exceptionDetails: { text: outcome.error, exception: { description: outcome.error } } };
@@ -104,27 +95,22 @@ export class WebDriverEvalBridge {
   }
 }
 
-/** Build a `WebDriverEvalBridge` from a live WDIO session (its connection host/port + sessionId). */
 export function createWebDriverEvalBridge(browser: WebdriverIO.Browser): WebDriverEvalBridge {
   const options = browser.options as { protocol?: string; hostname?: string; port?: number; path?: string };
   const protocol = options.protocol ?? 'http';
   const hostname = options.hostname ?? '127.0.0.1';
   const port = options.port ?? 4444;
-  // The launcher connects WDIO to WebKitWebDriver at the session root ('/'), so the base is
-  // just protocol://host:port.
   const baseUrl = `${protocol}://${hostname}:${port}`;
   return new WebDriverEvalBridge(httpExecuteAsyncPoster(baseUrl, browser.sessionId));
 }
 
 /**
- * Frontend log capture without CDP console events: a `console.*` shim buffers entries in-page,
- * and the returned reader drains them to the WDIO logger. These scripts never throw, so plain
- * `browser.execute` is fine here (unlike the eval channel above).
+ * Frontend log capture without CDP console events. Unlike the eval channel above, these scripts
+ * never throw, so plain `browser.execute` is fine.
  *
  * NOTE: the shim is per-document — a full-page navigation resets `window`, so entries logged
  * before a navigation are lost from the buffer. Cross-navigation frontend logs still surface via
- * the driver's stdout (electrobun forwards `console.*` there), which the launcher pipes to the
- * logger; this shim is the structured, in-page supplement to that live stream.
+ * the driver's stdout (electrobun forwards `console.*` there), which the launcher pipes to the logger.
  */
 export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<() => Promise<void>> {
   const installScript =
@@ -156,8 +142,6 @@ export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<
       )) as unknown as Array<{ level: string; args: string[] }>;
       for (const entry of entries ?? []) {
         const line = `[webview] ${entry.args.join(' ')}`;
-        // Preserve the console severity where the logger has a matching level; console.log and
-        // unknown levels fall back to info.
         const level = ['debug', 'info', 'warn', 'error'].includes(entry.level) ? entry.level : 'info';
         (log as unknown as Record<string, (msg: string) => void>)[level]?.(line);
       }

--- a/packages/electrobun-service/src/webdriverEval.ts
+++ b/packages/electrobun-service/src/webdriverEval.ts
@@ -14,20 +14,23 @@ import { SERVICE_NAME } from './constants.js';
 const log = createLogger(SERVICE_NAME, 'bridge');
 
 /** Outcome of evaluating an expression in the page (never throws for a page-level JS error). */
-type EvalOutcome = { ok: true; value: unknown } | { ok: false; error: string };
+type EvalOutcome = { ok: true; value: unknown; undef?: boolean } | { ok: false; error: string };
 
 /**
  * Evaluate an expression string in the app's realm over W3C `/execute/async` and resolve its
  * (awaited) value, or an error string for a page-level rejection. The expression is inlined
  * into the async script BODY (not `eval`/`Function`), so it works under a page CSP that forbids
  * `unsafe-eval`. `awaitPromise` semantics match CDP: the value is unwrapped from a Promise.
+ *
+ * `undef` flags a genuine `undefined` result so the caller can distinguish it from `null` —
+ * WebDriver serialises a bare `undefined` as `null`, unlike CDP's returnByValue.
  */
 async function runInPage(browser: WebdriverIO.Browser, expression: string): Promise<EvalOutcome> {
   // The W3C async script receives an injected callback as its last argument.
   const body =
     'var done = arguments[arguments.length - 1];' +
     `Promise.resolve().then(function () { return (${expression}); }).then(` +
-    'function (v) { done({ ok: true, value: v }); },' +
+    'function (v) { done({ ok: true, value: v, undef: v === undefined }); },' +
     'function (e) { done({ ok: false, error: String((e && e.stack) || e) }); });';
   return (await browser.executeAsync(body)) as EvalOutcome;
 }
@@ -53,7 +56,9 @@ export class WebDriverEvalBridge {
     }
     const outcome = await runInPage(this.browser, params.expression);
     if (outcome.ok) {
-      return { result: { value: outcome.value } };
+      // Preserve a genuine `undefined` result (WebDriver would otherwise surface it as `null`),
+      // matching the CDP path so the execute surface is convergent across transports.
+      return { result: { value: outcome.undef ? undefined : outcome.value } };
     }
     // Page-level JS error → mirror CDP's exceptionDetails so the caller wraps it with context.
     return { exceptionDetails: { text: outcome.error, exception: { description: outcome.error } } };
@@ -65,6 +70,11 @@ export class WebDriverEvalBridge {
  * `window.__WDIO_ELECTROBUN_LOGS__`, and return a reader that drains the buffer and forwards
  * entries to the WDIO logger. Frontend log capture without CDP console events (the WebKitGTK
  * path has none). Best-effort: injection/read failures are logged, not fatal.
+ *
+ * NOTE: the shim is per-document — a full-page navigation resets `window`, so entries logged
+ * before a navigation are lost from the buffer. Cross-navigation frontend logs still surface
+ * via the driver's stdout (electrobun forwards `console.*` there), which the launcher pipes to
+ * the logger; this shim is the structured, in-page supplement to that live stream.
  */
 export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<() => Promise<void>> {
   const installScript =
@@ -96,7 +106,9 @@ export async function installConsoleShim(browser: WebdriverIO.Browser): Promise<
       )) as unknown as Array<{ level: string; args: string[] }>;
       for (const entry of entries ?? []) {
         const line = `[webview] ${entry.args.join(' ')}`;
-        const level = entry.level === 'debug' ? 'debug' : entry.level === 'error' ? 'error' : 'info';
+        // Preserve the console severity where the logger has a matching level; console.log and
+        // unknown levels fall back to info.
+        const level = ['debug', 'info', 'warn', 'error'].includes(entry.level) ? entry.level : 'info';
         (log as unknown as Record<string, (msg: string) => void>)[level]?.(line);
       }
     } catch (error) {

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -17,7 +17,6 @@ import { SERVICE_NAME } from './constants.js';
 
 const log = createLogger(SERVICE_NAME, 'driver');
 
-/** A spawned `WebKitWebDriver` process bound to a host:port. */
 export interface WebKitDriverProcess {
   process: ChildProcess;
   host: string;
@@ -123,8 +122,7 @@ export async function spawnWebKitWebDriver(opts: {
   // Linux CI runners are headless, and WebKitWebDriver launches a GTK app that needs an X
   // display ("Failed to open X11 display" otherwise → New Session hangs). WDIO's autoXvfb
   // covers the worker process, NOT this launcher-spawned driver, so run it under `xvfb-run -a`
-  // (a throwaway X server) — mirroring the CEF app spawn in nativeMode.ts. This driver only
-  // runs on Linux; the guard keeps a local non-Linux run (there is none today) direct.
+  // (a throwaway X server) — mirroring the CEF app spawn in nativeMode.ts.
   const useXvfb = process.platform === 'linux';
   const command = useXvfb ? 'xvfb-run' : opts.driverPath;
   const spawnArgs = useXvfb ? ['-a', opts.driverPath, ...driverArgs] : driverArgs;

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -1,8 +1,7 @@
 // Spawn + manage `WebKitWebDriver` for the Linux WebKitGTK (W3C WebDriver) transport.
 //
 // Unlike the CDP-attach path (macOS CEF / Windows WebView2), where the service spawns the app and a
-// Chromedriver attaches, `WebKitWebDriver` is itself the W3C server and it LAUNCHES the app (via
-// `webkitgtk:browserOptions.binary` + `--automation`).
+// Chromedriver attaches, `WebKitWebDriver` is itself the W3C server and it LAUNCHES the app.
 
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -21,8 +20,8 @@ export interface WebKitDriverProcess {
   detached: boolean;
 }
 
-// Common install locations, tried after `which`. The `webkit2gtk-driver` package installs
-// `/usr/bin/WebKitWebDriver`; the versioned libdir paths cover distros that don't symlink it.
+// The `webkit2gtk-driver` package installs `/usr/bin/WebKitWebDriver`; the versioned libdir
+// paths cover distros that don't symlink it.
 const COMMON_DRIVER_PATHS = [
   '/usr/bin/WebKitWebDriver',
   '/usr/local/bin/WebKitWebDriver',
@@ -72,8 +71,7 @@ export async function waitForWebKitWebDriverReady(
       const res = await fetchImpl(`http://${host}:${port}/status`);
       if (res.ok) {
         const body = (await res.json()) as { value?: { ready?: boolean } };
-        // WebKitWebDriver reports `{ value: { ready, message } }`; treat a 200 with a value as
-        // usable even if `ready` is momentarily false — New Session then blocks until ready.
+        // A 200 with a `value` is enough; New Session blocks until ready, so a transient `ready: false` is fine.
         if (body?.value) {
           return;
         }
@@ -89,7 +87,6 @@ export async function waitForWebKitWebDriverReady(
   );
 }
 
-/** The app is NOT launched here — the driver launches it when the worker opens its session. */
 export async function spawnWebKitWebDriver(opts: {
   driverPath: string;
   port: number;
@@ -99,10 +96,9 @@ export async function spawnWebKitWebDriver(opts: {
   const host = opts.host ?? '127.0.0.1';
   const driverArgs = webKitWebDriverArgs(host, opts.port);
 
-  // Linux CI runners are headless, and WebKitWebDriver launches a GTK app that needs an X
-  // display ("Failed to open X11 display" otherwise → New Session hangs). WDIO's autoXvfb
-  // covers the worker process, NOT this launcher-spawned driver, so run it under `xvfb-run -a`
-  // (a throwaway X server) — mirroring the CEF app spawn in nativeMode.ts.
+  // Linux CI runners are headless and WebKitWebDriver launches a GTK app that needs an X display.
+  // WDIO's autoXvfb wraps the worker process, NOT this launcher-spawned driver, so run it under
+  // `xvfb-run -a` — mirroring the CEF app spawn in nativeMode.ts.
   const useXvfb = process.platform === 'linux';
   const command = useXvfb ? 'xvfb-run' : opts.driverPath;
   const spawnArgs = useXvfb ? ['-a', opts.driverPath, ...driverArgs] : driverArgs;
@@ -111,17 +107,16 @@ export async function spawnWebKitWebDriver(opts: {
   // Detach on Linux so xvfb-run becomes its own process-group leader: `xvfb-run` does NOT forward
   // signals to WebKitWebDriver (its child) or the app (WebKitWebDriver's child), so killing just
   // the xvfb-run pid orphans them — across retries the orphaned apps + X servers pile up and
-  // starve the runner (New Session then times out). Detaching lets teardown kill the whole group.
+  // starve the runner. Detaching lets teardown kill the whole group.
   const child = spawn(command, spawnArgs, { stdio: ['ignore', 'pipe', 'pipe'], detached: useXvfb });
   child.stdout?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver] ${chunk.toString().trimEnd()}`));
   child.stderr?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver:err] ${chunk.toString().trimEnd()}`));
   child.on('exit', (code) => log.debug(`WebKitWebDriver exited with code ${code}`));
-  // A spawn failure (ENOENT/EACCES) emits 'error'; without a handler Node re-throws it as an
-  // uncaught exception and crashes the launcher.
+  // Without this handler an 'error' event (e.g. spawn ENOENT) crashes the launcher as an uncaught exception.
   child.on('error', (error) => log.warn(`WebKitWebDriver process error: ${(error as Error).message}`));
 
   const handle: WebKitDriverProcess = { process: child, host, port: opts.port, detached: useXvfb };
-  // Fail the readiness wait fast on a spawn error rather than blocking for the full timeout.
+  // If the spawn errors, reject immediately instead of waiting out the full readiness timeout.
   const spawnFailed = new Promise<never>((_, reject) => {
     child.once('error', (error: Error) =>
       reject(new Error(`Failed to spawn WebKitWebDriver (${command}): ${error.message}`)),
@@ -137,13 +132,13 @@ export async function spawnWebKitWebDriver(opts: {
   return handle;
 }
 
-/** SIGTERM then SIGKILL — the fallback matters because WebKitWebDriver can be slow to release a session. */
+/** SIGTERM, then SIGKILL to force exit when WebKitWebDriver is slow to release the session. */
 export async function stopWebKitWebDriver(handle: WebKitDriverProcess, killTimeoutMs = KILL_TIMEOUT_MS): Promise<void> {
   const { process: child, detached } = handle;
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
   }
-  // Signal the whole process GROUP (negative pid) when detached, so xvfb-run + WebKitWebDriver +
+  // When detached, signal the process group with a negative pid, so xvfb-run + WebKitWebDriver +
   // the app all die — killing only the xvfb-run pid leaves the driver and app orphaned. Falls
   // back to the single child if the group is already gone or we didn't detach.
   const signalTree = (signal: NodeJS.Signals) => {
@@ -153,7 +148,7 @@ export async function stopWebKitWebDriver(handle: WebKitDriverProcess, killTimeo
         return;
       }
     } catch {
-      // group gone / not a leader — fall through to the direct kill
+      // the process group is already gone — fall through to the direct kill
     }
     child.kill(signal);
   };

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -22,6 +22,8 @@ export interface WebKitDriverProcess {
   process: ChildProcess;
   host: string;
   port: number;
+  /** Spawned detached (its own process group) so teardown can kill the whole xvfb-run tree. */
+  detached: boolean;
 }
 
 // Common install locations, tried after `which`. The `webkit2gtk-driver` package installs
@@ -128,7 +130,11 @@ export async function spawnWebKitWebDriver(opts: {
   const spawnArgs = useXvfb ? ['-a', opts.driverPath, ...driverArgs] : driverArgs;
 
   log.debug(`Spawning WebKitWebDriver: ${command} ${spawnArgs.join(' ')}`);
-  const child = spawn(command, spawnArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+  // Detach on Linux so xvfb-run becomes its own process-group leader: `xvfb-run` does NOT forward
+  // signals to WebKitWebDriver (its child) or the app (WebKitWebDriver's child), so killing just
+  // the xvfb-run pid orphans them — across retries the orphaned apps + X servers pile up and
+  // starve the runner (New Session then times out). Detaching lets teardown kill the whole group.
+  const child = spawn(command, spawnArgs, { stdio: ['ignore', 'pipe', 'pipe'], detached: useXvfb });
   child.stdout?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver] ${chunk.toString().trimEnd()}`));
   child.stderr?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver:err] ${chunk.toString().trimEnd()}`));
   child.on('exit', (code) => log.debug(`WebKitWebDriver exited with code ${code}`));
@@ -136,7 +142,7 @@ export async function spawnWebKitWebDriver(opts: {
   // uncaught exception and crashes the launcher. Always handle it.
   child.on('error', (error) => log.warn(`WebKitWebDriver process error: ${(error as Error).message}`));
 
-  const handle: WebKitDriverProcess = { process: child, host, port: opts.port };
+  const handle: WebKitDriverProcess = { process: child, host, port: opts.port, detached: useXvfb };
   // Fail the readiness wait fast on a spawn error rather than blocking for the full timeout.
   const spawnFailed = new Promise<never>((_, reject) => {
     child.once('error', (error: Error) =>
@@ -159,19 +165,33 @@ export async function spawnWebKitWebDriver(opts: {
  * to release a session on teardown, so the SIGKILL fallback matters.
  */
 export async function stopWebKitWebDriver(handle: WebKitDriverProcess, killTimeoutMs = KILL_TIMEOUT_MS): Promise<void> {
-  const { process: child } = handle;
+  const { process: child, detached } = handle;
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
   }
+  // Signal the whole process GROUP (negative pid) when detached, so xvfb-run + WebKitWebDriver +
+  // the app all die — killing only the xvfb-run pid leaves the driver and app orphaned. Falls
+  // back to the single child if the group is already gone or we didn't detach.
+  const signalTree = (signal: NodeJS.Signals) => {
+    try {
+      if (detached && child.pid !== undefined) {
+        process.kill(-child.pid, signal);
+        return;
+      }
+    } catch {
+      // group gone / not a leader — fall through to the direct kill
+    }
+    child.kill(signal);
+  };
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
-      child.kill('SIGKILL');
+      signalTree('SIGKILL');
       resolve();
     }, killTimeoutMs);
     child.once('exit', () => {
       clearTimeout(timer);
       resolve();
     });
-    child.kill('SIGTERM');
+    signalTree('SIGTERM');
   });
 }

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -1,0 +1,158 @@
+// Spawn + manage `WebKitWebDriver` for the Linux WebKitGTK (W3C WebDriver) transport.
+//
+// Unlike the CDP-attach path (macOS CEF / Windows WebView2), where the service spawns the app
+// and a Chromedriver attaches, WebKitGTK inverts this: `WebKitWebDriver` is the W3C server, and
+// it LAUNCHES the app (via `webkitgtk:browserOptions.binary` + `--automation`) when the worker
+// creates a session. So the launcher spawns this driver per worker and points WDIO's connection
+// at it (hostname/port); the driver owns the app process. No Rust intermediary is needed —
+// electrobun 2.0.1 exposes WebKitGTK automation upstream (#467), so the app is driven the same
+// way `WebKitWebDriver` drives MiniBrowser.
+
+import { type ChildProcess, execSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+import { createLogger } from '@wdio/native-utils';
+
+import { SERVICE_NAME } from './constants.js';
+
+const log = createLogger(SERVICE_NAME, 'driver');
+
+/** A spawned `WebKitWebDriver` process bound to a host:port. */
+export interface WebKitDriverProcess {
+  process: ChildProcess;
+  host: string;
+  port: number;
+}
+
+// Common install locations, tried after `which`. The `webkit2gtk-driver` package installs
+// `/usr/bin/WebKitWebDriver`; the versioned libdir paths cover distros that don't symlink it.
+const COMMON_DRIVER_PATHS = [
+  '/usr/bin/WebKitWebDriver',
+  '/usr/local/bin/WebKitWebDriver',
+  '/usr/lib/webkit2gtk-4.1/WebKitWebDriver',
+  '/usr/lib/webkit2gtk-4.0/WebKitWebDriver',
+];
+
+/**
+ * Locate the `WebKitWebDriver` binary on Linux (PATH first, then common install paths), or
+ * `undefined` if not found / not on Linux. The launcher turns `undefined` into an actionable
+ * install error (`webKitWebDriverNotFound`).
+ */
+export function getWebKitWebDriverPath(platform: NodeJS.Platform = process.platform): string | undefined {
+  if (platform !== 'linux') {
+    return undefined;
+  }
+  try {
+    const found = execSync('which WebKitWebDriver', { encoding: 'utf8' }).trim();
+    if (found && existsSync(found)) {
+      log.debug(`Found WebKitWebDriver at: ${found}`);
+      return found;
+    }
+  } catch {
+    log.debug('WebKitWebDriver not found in PATH');
+  }
+  for (const candidate of COMMON_DRIVER_PATHS) {
+    if (existsSync(candidate)) {
+      log.debug(`Found WebKitWebDriver at: ${candidate}`);
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the `WebKitWebDriver` CLI args. IMPORTANT: the flags are equals-form — `--port=N`,
+ * `--host=H`. Space-form (`--port N`) makes WebKitWebDriver print usage and exit 1.
+ */
+export function webKitWebDriverArgs(host: string, port: number): string[] {
+  return [`--host=${host}`, `--port=${port}`];
+}
+
+/** How long to wait after SIGTERM before escalating to SIGKILL (longer on CI). */
+const KILL_TIMEOUT_MS = process.env.CI ? 10_000 : 5_000;
+
+/**
+ * Poll `WebKitWebDriver`'s `/status` until it reports ready, or throw on timeout. `fetchImpl`
+ * is injectable for tests.
+ */
+export async function waitForWebKitWebDriverReady(
+  host: string,
+  port: number,
+  timeoutMs = 15_000,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetchImpl(`http://${host}:${port}/status`);
+      if (res.ok) {
+        const body = (await res.json()) as { value?: { ready?: boolean } };
+        // WebKitWebDriver reports `{ value: { ready, message } }`; treat a 200 with a value as
+        // usable even if `ready` is momentarily false — New Session then blocks until ready.
+        if (body?.value) {
+          return;
+        }
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(
+    `WebKitWebDriver did not become ready on ${host}:${port} within ${timeoutMs}ms` +
+      (lastError ? `: ${(lastError as Error).message}` : ''),
+  );
+}
+
+/**
+ * Spawn `WebKitWebDriver` on `port` and wait until it is ready to accept sessions. The app is
+ * NOT launched here — the driver launches it when the worker opens its session.
+ */
+export async function spawnWebKitWebDriver(opts: {
+  driverPath: string;
+  port: number;
+  host?: string;
+  readyTimeoutMs?: number;
+}): Promise<WebKitDriverProcess> {
+  const host = opts.host ?? '127.0.0.1';
+  log.debug(`Spawning WebKitWebDriver: ${opts.driverPath} ${webKitWebDriverArgs(host, opts.port).join(' ')}`);
+  const child = spawn(opts.driverPath, webKitWebDriverArgs(host, opts.port), {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver] ${chunk.toString().trimEnd()}`));
+  child.stderr?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver:err] ${chunk.toString().trimEnd()}`));
+  child.on('exit', (code) => log.debug(`WebKitWebDriver exited with code ${code}`));
+
+  const handle: WebKitDriverProcess = { process: child, host, port: opts.port };
+  try {
+    await waitForWebKitWebDriverReady(host, opts.port, opts.readyTimeoutMs);
+  } catch (error) {
+    await stopWebKitWebDriver(handle).catch(() => {});
+    throw error;
+  }
+  return handle;
+}
+
+/**
+ * Stop a `WebKitWebDriver` process: SIGTERM, then SIGKILL if it doesn't exit within the
+ * timeout. Killing the driver also tears down the app it launched. WebKitWebDriver can be slow
+ * to release a session on teardown, so the SIGKILL fallback matters.
+ */
+export async function stopWebKitWebDriver(handle: WebKitDriverProcess, killTimeoutMs = KILL_TIMEOUT_MS): Promise<void> {
+  const { process: child } = handle;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve();
+    }, killTimeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.kill('SIGTERM');
+  });
+}

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -116,17 +116,36 @@ export async function spawnWebKitWebDriver(opts: {
   readyTimeoutMs?: number;
 }): Promise<WebKitDriverProcess> {
   const host = opts.host ?? '127.0.0.1';
-  log.debug(`Spawning WebKitWebDriver: ${opts.driverPath} ${webKitWebDriverArgs(host, opts.port).join(' ')}`);
-  const child = spawn(opts.driverPath, webKitWebDriverArgs(host, opts.port), {
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  const driverArgs = webKitWebDriverArgs(host, opts.port);
+
+  // Linux CI runners are headless, and WebKitWebDriver launches a GTK app that needs an X
+  // display ("Failed to open X11 display" otherwise → New Session hangs). WDIO's autoXvfb
+  // covers the worker process, NOT this launcher-spawned driver, so run it under `xvfb-run -a`
+  // (a throwaway X server) — mirroring the CEF app spawn in nativeMode.ts. This driver only
+  // runs on Linux; the guard keeps a local non-Linux run (there is none today) direct.
+  const useXvfb = process.platform === 'linux';
+  const command = useXvfb ? 'xvfb-run' : opts.driverPath;
+  const spawnArgs = useXvfb ? ['-a', opts.driverPath, ...driverArgs] : driverArgs;
+
+  log.debug(`Spawning WebKitWebDriver: ${command} ${spawnArgs.join(' ')}`);
+  const child = spawn(command, spawnArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
   child.stdout?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver] ${chunk.toString().trimEnd()}`));
   child.stderr?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver:err] ${chunk.toString().trimEnd()}`));
   child.on('exit', (code) => log.debug(`WebKitWebDriver exited with code ${code}`));
+  // A spawn failure (ENOENT/EACCES) emits 'error'; without a handler Node re-throws it as an
+  // uncaught exception and crashes the launcher. Always handle it.
+  child.on('error', (error) => log.warn(`WebKitWebDriver process error: ${(error as Error).message}`));
 
   const handle: WebKitDriverProcess = { process: child, host, port: opts.port };
+  // Fail the readiness wait fast on a spawn error rather than blocking for the full timeout.
+  const spawnFailed = new Promise<never>((_, reject) => {
+    child.once('error', (error: Error) =>
+      reject(new Error(`Failed to spawn WebKitWebDriver (${command}): ${error.message}`)),
+    );
+  });
+  spawnFailed.catch(() => {}); // no-op catch: avoids an unhandled rejection if 'error' fires post-readiness
   try {
-    await waitForWebKitWebDriverReady(host, opts.port, opts.readyTimeoutMs);
+    await Promise.race([waitForWebKitWebDriverReady(host, opts.port, opts.readyTimeoutMs), spawnFailed]);
   } catch (error) {
     await stopWebKitWebDriver(handle).catch(() => {});
     throw error;

--- a/packages/electrobun-service/src/webkitDriver.ts
+++ b/packages/electrobun-service/src/webkitDriver.ts
@@ -1,12 +1,8 @@
 // Spawn + manage `WebKitWebDriver` for the Linux WebKitGTK (W3C WebDriver) transport.
 //
-// Unlike the CDP-attach path (macOS CEF / Windows WebView2), where the service spawns the app
-// and a Chromedriver attaches, WebKitGTK inverts this: `WebKitWebDriver` is the W3C server, and
-// it LAUNCHES the app (via `webkitgtk:browserOptions.binary` + `--automation`) when the worker
-// creates a session. So the launcher spawns this driver per worker and points WDIO's connection
-// at it (hostname/port); the driver owns the app process. No Rust intermediary is needed —
-// electrobun 2.0.1 exposes WebKitGTK automation upstream (#467), so the app is driven the same
-// way `WebKitWebDriver` drives MiniBrowser.
+// Unlike the CDP-attach path (macOS CEF / Windows WebView2), where the service spawns the app and a
+// Chromedriver attaches, `WebKitWebDriver` is itself the W3C server and it LAUNCHES the app (via
+// `webkitgtk:browserOptions.binary` + `--automation`).
 
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -34,11 +30,6 @@ const COMMON_DRIVER_PATHS = [
   '/usr/lib/webkit2gtk-4.0/WebKitWebDriver',
 ];
 
-/**
- * Locate the `WebKitWebDriver` binary on Linux (PATH first, then common install paths), or
- * `undefined` if not found / not on Linux. The launcher turns `undefined` into an actionable
- * install error (`webKitWebDriverNotFound`).
- */
 export function getWebKitWebDriverPath(platform: NodeJS.Platform = process.platform): string | undefined {
   if (platform !== 'linux') {
     return undefined;
@@ -61,21 +52,13 @@ export function getWebKitWebDriverPath(platform: NodeJS.Platform = process.platf
   return undefined;
 }
 
-/**
- * Build the `WebKitWebDriver` CLI args. IMPORTANT: the flags are equals-form — `--port=N`,
- * `--host=H`. Space-form (`--port N`) makes WebKitWebDriver print usage and exit 1.
- */
+/** IMPORTANT: equals-form flags. Space-form (`--port N`) makes WebKitWebDriver print usage and exit 1. */
 export function webKitWebDriverArgs(host: string, port: number): string[] {
   return [`--host=${host}`, `--port=${port}`];
 }
 
-/** How long to wait after SIGTERM before escalating to SIGKILL (longer on CI). */
 const KILL_TIMEOUT_MS = process.env.CI ? 10_000 : 5_000;
 
-/**
- * Poll `WebKitWebDriver`'s `/status` until it reports ready, or throw on timeout. `fetchImpl`
- * is injectable for tests.
- */
 export async function waitForWebKitWebDriverReady(
   host: string,
   port: number,
@@ -106,10 +89,7 @@ export async function waitForWebKitWebDriverReady(
   );
 }
 
-/**
- * Spawn `WebKitWebDriver` on `port` and wait until it is ready to accept sessions. The app is
- * NOT launched here — the driver launches it when the worker opens its session.
- */
+/** The app is NOT launched here — the driver launches it when the worker opens its session. */
 export async function spawnWebKitWebDriver(opts: {
   driverPath: string;
   port: number;
@@ -137,7 +117,7 @@ export async function spawnWebKitWebDriver(opts: {
   child.stderr?.on('data', (chunk: Buffer) => log.debug(`[WebKitWebDriver:err] ${chunk.toString().trimEnd()}`));
   child.on('exit', (code) => log.debug(`WebKitWebDriver exited with code ${code}`));
   // A spawn failure (ENOENT/EACCES) emits 'error'; without a handler Node re-throws it as an
-  // uncaught exception and crashes the launcher. Always handle it.
+  // uncaught exception and crashes the launcher.
   child.on('error', (error) => log.warn(`WebKitWebDriver process error: ${(error as Error).message}`));
 
   const handle: WebKitDriverProcess = { process: child, host, port: opts.port, detached: useXvfb };
@@ -147,7 +127,7 @@ export async function spawnWebKitWebDriver(opts: {
       reject(new Error(`Failed to spawn WebKitWebDriver (${command}): ${error.message}`)),
     );
   });
-  spawnFailed.catch(() => {}); // no-op catch: avoids an unhandled rejection if 'error' fires post-readiness
+  spawnFailed.catch(() => {}); // avoids an unhandled rejection if 'error' fires after readiness
   try {
     await Promise.race([waitForWebKitWebDriverReady(host, opts.port, opts.readyTimeoutMs), spawnFailed]);
   } catch (error) {
@@ -157,11 +137,7 @@ export async function spawnWebKitWebDriver(opts: {
   return handle;
 }
 
-/**
- * Stop a `WebKitWebDriver` process: SIGTERM, then SIGKILL if it doesn't exit within the
- * timeout. Killing the driver also tears down the app it launched. WebKitWebDriver can be slow
- * to release a session on teardown, so the SIGKILL fallback matters.
- */
+/** SIGTERM then SIGKILL — the fallback matters because WebKitWebDriver can be slow to release a session. */
 export async function stopWebKitWebDriver(handle: WebKitDriverProcess, killTimeoutMs = KILL_TIMEOUT_MS): Promise<void> {
   const { process: child, detached } = handle;
   if (child.exitCode !== null || child.signalCode !== null) {

--- a/packages/electrobun-service/test/errors.spec.ts
+++ b/packages/electrobun-service/test/errors.spec.ts
@@ -5,6 +5,7 @@ import {
   cefRendererRequired,
   deeplinkUnsupportedOnPlatform,
   nativeRendererUnsupportedPlatform,
+  webKitWebDriverNotFound,
 } from '../src/errors.js';
 
 describe('cefRendererRequired', () => {
@@ -31,22 +32,38 @@ describe('nativeRendererUnsupportedPlatform', () => {
   });
 
   it('should name the unsupported platform and the supported renderers', () => {
-    const err = nativeRendererUnsupportedPlatform('linux');
-    expect(err.message).toContain('linux');
+    const err = nativeRendererUnsupportedPlatform('freebsd' as NodeJS.Platform);
+    expect(err.message).toContain('freebsd');
     expect(err.message).toContain('CEF');
     expect(err.message).toContain('WebView2');
+    expect(err.message).toContain('WebKitGTK');
   });
 
-  it('should include the renderer when given (e.g. a CEF build on Windows)', () => {
+  it('should include the renderer when given (e.g. a CEF build off macOS)', () => {
     const err = nativeRendererUnsupportedPlatform('win32', 'cef');
     expect(err.message).toContain('win32');
     expect(err.message).toContain('renderer: cef');
   });
 
-  it('should point to browser mode and the #317 native-renderer follow-up', () => {
-    const err = nativeRendererUnsupportedPlatform('linux');
+  it('should guide a CEF build off macOS to the native renderer', () => {
+    for (const platform of ['win32', 'linux'] as const) {
+      const err = nativeRendererUnsupportedPlatform(platform, 'cef');
+      expect(err.message).toContain('defaultRenderer: "native"');
+    }
+  });
+
+  it('should point an unsupported platform to browser mode', () => {
+    const err = nativeRendererUnsupportedPlatform('freebsd' as NodeJS.Platform);
     expect(err.message).toContain("mode: 'browser'");
-    expect(err.message).toContain('issues/317');
+  });
+});
+
+describe('webKitWebDriverNotFound', () => {
+  it('should be a SevereServiceError naming the install package', () => {
+    const err = webKitWebDriverNotFound();
+    expect(err).toBeInstanceOf(SevereServiceError);
+    expect(err.message).toContain('WebKitWebDriver');
+    expect(err.message).toContain('webkit2gtk-driver');
   });
 });
 

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -54,6 +54,7 @@ vi.mock('../src/webkitDriver.js', () => ({
     process: { pid: 5555, exitCode: null, signalCode: null, kill: vi.fn() },
     host: '127.0.0.1',
     port: 9333,
+    detached: true,
   })),
   stopWebKitWebDriver: vi.fn().mockResolvedValue(undefined),
 }));

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -329,7 +329,8 @@ describe('ElectrobunLaunchService', () => {
       const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
       expect(error).toBeInstanceOf(SevereServiceError);
       expect((error as Error).message).toContain('win32');
-      expect((error as Error).message).toContain('issues/317');
+      // A CEF build off macOS is guided to the native renderer (it serves no /json there).
+      expect((error as Error).message).toContain('defaultRenderer: "native"');
     });
   });
 

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -205,6 +205,17 @@ describe('ElectrobunLaunchService', () => {
       expect(logMocks.warn).not.toHaveBeenCalledWith(expect.stringContaining('maxInstances'));
     });
 
+    it('should warn (not throw) when maxInstances > 1 on Linux — WebKitGTK apps share the bundle', async () => {
+      setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce(linuxNativeApp);
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher' });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare({ maxInstances: 2 } as Parameters<typeof launcher.onPrepare>[0], caps);
+
+      expect(logMocks.warn).toHaveBeenCalledWith(expect.stringContaining('maxInstances'));
+    });
+
     it('should pin browserVersion to the WebView2 runtime version on the Windows WebView2 path', async () => {
       setPlatform('win32');
       vi.mocked(resolveElectrobunApp).mockReturnValueOnce({

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -47,7 +47,6 @@ vi.mock('../src/webview2Version.js', () => ({
   detectWebView2RuntimeVersion: vi.fn(() => '148.0.3967.83'),
 }));
 
-// Mock the WebKitGTK (Linux/W3C) driver so no real WebKitWebDriver process is spawned.
 vi.mock('../src/webkitDriver.js', () => ({
   getWebKitWebDriverPath: vi.fn(() => '/usr/bin/WebKitWebDriver'),
   spawnWebKitWebDriver: vi.fn(async () => ({
@@ -59,7 +58,6 @@ vi.mock('../src/webkitDriver.js', () => ({
   stopWebKitWebDriver: vi.fn().mockResolvedValue(undefined),
 }));
 
-/** A resolved Linux native (WebKitGTK) app for the W3C-path tests. */
 const linuxNativeApp = {
   binaryPath: '/apps/Demo/bin/launcher',
   bundlePath: '/apps/Demo',
@@ -323,7 +321,6 @@ describe('ElectrobunLaunchService', () => {
 
       await launcher.onPrepare(baseConfig, caps);
 
-      // W3C: no CEF verify, WebKitWebDriver resolved once, browserName deleted, classic forced.
       expect(vi.mocked(verifyCefRenderer)).not.toHaveBeenCalled();
       expect(vi.mocked(getWebKitWebDriverPath)).toHaveBeenCalledTimes(1);
       const cap = caps[0] as Record<string, unknown>;
@@ -394,7 +391,6 @@ describe('ElectrobunLaunchService', () => {
       const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
       expect(error).toBeInstanceOf(SevereServiceError);
       expect((error as Error).message).toContain('win32');
-      // A CEF build off macOS is guided to the native renderer (it serves no /json there).
       expect((error as Error).message).toContain('defaultRenderer: "native"');
     });
   });
@@ -439,7 +435,6 @@ describe('ElectrobunLaunchService', () => {
       const cap: ElectrobunCapabilities = {};
       await launcher.onWorkerStart('0-0', [cap]);
 
-      // W3C: WebKitWebDriver launches the app, so the service does NOT spawn the app itself.
       expect(vi.mocked(spawnElectrobunApp)).not.toHaveBeenCalled();
       expect(vi.mocked(spawnWebKitWebDriver)).toHaveBeenCalledTimes(1);
       const w3cCap = cap as Record<string, unknown>;
@@ -526,7 +521,6 @@ describe('ElectrobunLaunchService', () => {
 
     it('should throw SevereServiceError when no app was resolved (onPrepare skipped)', async () => {
       const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
-      // Note: onPrepare intentionally NOT called.
       await expect(launcher.onWorkerStart('0-0', [{}])).rejects.toThrow(/no resolved Electrobun app/);
     });
 

--- a/packages/electrobun-service/test/launcher.spec.ts
+++ b/packages/electrobun-service/test/launcher.spec.ts
@@ -47,6 +47,27 @@ vi.mock('../src/webview2Version.js', () => ({
   detectWebView2RuntimeVersion: vi.fn(() => '148.0.3967.83'),
 }));
 
+// Mock the WebKitGTK (Linux/W3C) driver so no real WebKitWebDriver process is spawned.
+vi.mock('../src/webkitDriver.js', () => ({
+  getWebKitWebDriverPath: vi.fn(() => '/usr/bin/WebKitWebDriver'),
+  spawnWebKitWebDriver: vi.fn(async () => ({
+    process: { pid: 5555, exitCode: null, signalCode: null, kill: vi.fn() },
+    host: '127.0.0.1',
+    port: 9333,
+  })),
+  stopWebKitWebDriver: vi.fn().mockResolvedValue(undefined),
+}));
+
+/** A resolved Linux native (WebKitGTK) app for the W3C-path tests. */
+const linuxNativeApp = {
+  binaryPath: '/apps/Demo/bin/launcher',
+  bundlePath: '/apps/Demo',
+  resourcesDir: '/apps/Demo/Resources',
+  buildJsonPath: '/apps/Demo/Resources/build.json',
+  identifier: 'com.example.demo',
+  renderer: 'native',
+};
+
 vi.mock('@wdio/native-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@wdio/native-core')>()),
   startManagedDevServer: vi.fn(),
@@ -57,6 +78,7 @@ import { resolveElectrobunApp, verifyCefRenderer, writeRemoteDebuggingPort } fro
 import ElectrobunLaunchService from '../src/launcher.js';
 import { spawnElectrobunApp, stopElectrobunApp } from '../src/nativeMode.js';
 import type { ElectrobunCapabilities, ElectrobunServiceGlobalOptions } from '../src/types.js';
+import { getWebKitWebDriverPath, spawnWebKitWebDriver, stopWebKitWebDriver } from '../src/webkitDriver.js';
 import { detectWebView2RuntimeVersion } from '../src/webview2Version.js';
 
 const baseConfig = {} as Parameters<ElectrobunLaunchService['onPrepare']>[0];
@@ -292,8 +314,50 @@ describe('ElectrobunLaunchService', () => {
       expect(vi.mocked(resolveElectrobunApp)).toHaveBeenCalledWith('/apps/PerCap.app');
     });
 
-    it('should fail fast with a SevereServiceError in native mode on Linux (no CDP surface yet)', async () => {
+    it('should drive Linux via WebKitGTK/W3C for the native renderer (no browserName, classic)', async () => {
       setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce(linuxNativeApp);
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher', appArgs: ['--flag'] });
+      const caps: ElectrobunCapabilities[] = [{ browserName: 'electrobun' }];
+
+      await launcher.onPrepare(baseConfig, caps);
+
+      // W3C: no CEF verify, WebKitWebDriver resolved once, browserName deleted, classic forced.
+      expect(vi.mocked(verifyCefRenderer)).not.toHaveBeenCalled();
+      expect(vi.mocked(getWebKitWebDriverPath)).toHaveBeenCalledTimes(1);
+      const cap = caps[0] as Record<string, unknown>;
+      expect(cap.browserName).toBeUndefined();
+      expect(cap['wdio:enforceWebDriverClassic']).toBe(true);
+      expect(cap['webkitgtk:browserOptions']).toEqual({
+        binary: '/apps/Demo/bin/launcher',
+        args: ['--automation', '--flag'],
+      });
+    });
+
+    it('should reject a CEF-built bundle on Linux (CEF serves no /json there)', async () => {
+      setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce({ ...linuxNativeApp, renderer: 'cef' });
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher' });
+
+      const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(SevereServiceError);
+      expect((error as Error).message).toContain('linux');
+      expect((error as Error).message).toContain('defaultRenderer: "native"');
+    });
+
+    it('should fail fast with an install hint when WebKitWebDriver is missing on Linux', async () => {
+      setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce(linuxNativeApp);
+      vi.mocked(getWebKitWebDriverPath).mockReturnValueOnce(undefined);
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher' });
+
+      const error = await launcher.onPrepare(baseConfig, [{}]).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(SevereServiceError);
+      expect((error as Error).message).toContain('webkit2gtk-driver');
+    });
+
+    it('should fail fast with a SevereServiceError in native mode on an unsupported platform', async () => {
+      setPlatform('freebsd' as NodeJS.Platform);
       const launcher = makeLauncher({ appBinaryPath: '/apps/Demo.app' });
 
       await expect(launcher.onPrepare(baseConfig, [{}])).rejects.toThrow(SevereServiceError);
@@ -363,6 +427,36 @@ describe('ElectrobunLaunchService', () => {
       // Edge reads debuggerAddress from ms:edgeOptions, not goog:chromeOptions.
       expect(cap['ms:edgeOptions']).toEqual({ debuggerAddress: `127.0.0.1:${spawnArg.port}` });
       expect(cap['goog:chromeOptions']).toBeUndefined();
+    });
+
+    it('should spawn WebKitWebDriver and set connection host/port on the Linux/W3C path', async () => {
+      setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce(linuxNativeApp);
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher' });
+      await launcher.onPrepare(baseConfig, [{}]);
+
+      const cap: ElectrobunCapabilities = {};
+      await launcher.onWorkerStart('0-0', [cap]);
+
+      // W3C: WebKitWebDriver launches the app, so the service does NOT spawn the app itself.
+      expect(vi.mocked(spawnElectrobunApp)).not.toHaveBeenCalled();
+      expect(vi.mocked(spawnWebKitWebDriver)).toHaveBeenCalledTimes(1);
+      const w3cCap = cap as Record<string, unknown>;
+      expect(w3cCap.hostname).toBe('127.0.0.1');
+      expect(w3cCap.port).toBe(9333);
+      expect(w3cCap['goog:chromeOptions']).toBeUndefined();
+    });
+
+    it('should stop WebKitWebDriver on worker end (Linux/W3C)', async () => {
+      setPlatform('linux');
+      vi.mocked(resolveElectrobunApp).mockReturnValueOnce(linuxNativeApp);
+      const launcher = makeLauncher({ appBinaryPath: '/apps/Demo/bin/launcher' });
+      await launcher.onPrepare(baseConfig, [{}]);
+      await launcher.onWorkerStart('0-0', [{}]);
+
+      await launcher.onWorkerEnd('0-0');
+
+      expect(vi.mocked(stopWebKitWebDriver)).toHaveBeenCalledTimes(1);
     });
 
     it('should spawn one app per instance for a multiremote capability record', async () => {

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -495,10 +495,36 @@ describe('ElectrobunWorkerService', () => {
 
         await service.after();
 
-        // pkill matches the app bundle root so WDIO's subsequent deleteSession returns fast.
+        // pkill matches the app bundle root (escaped + anchored to argv0) so WDIO's subsequent
+        // deleteSession returns fast without risking unrelated processes.
         expect(execFileSyncMock).toHaveBeenCalledWith(
           'pkill',
-          ['-9', '-f', '/home/runner/build/WDIOElectrobunE2E-dev'],
+          ['-9', '-f', '^/home/runner/build/WDIOElectrobunE2E-dev/'],
+          expect.anything(),
+        );
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      }
+    });
+
+    it('should escape regex metacharacters in the reap pattern (no pkill injection)', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      try {
+        const browser = makeW3CBrowser();
+        const cap = {
+          'webkitgtk:browserOptions': { binary: '/home/runner/b/My.App+v2/bin/launcher', args: ['--automation'] },
+        };
+        const service = new ElectrobunWorkerService({}, {});
+        await service.before(cap, [], browser);
+        execFileSyncMock.mockClear();
+
+        await service.after();
+
+        // `.` and `+` are escaped; anchored to argv0 under the bundle dir.
+        expect(execFileSyncMock).toHaveBeenCalledWith(
+          'pkill',
+          ['-9', '-f', '^/home/runner/b/My\\.App\\+v2/'],
           expect.anything(),
         );
       } finally {

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -467,9 +467,14 @@ describe('ElectrobunWorkerService', () => {
       const installed = browser.execute.mock.calls.some((c) => String(c[0]).includes('__WDIO_ELECTROBUN_LOGS__'));
       expect(installed).toBe(true);
 
+      // Teardown must drain a populated buffer (not the empty default), so the buffer→logger path
+      // actually runs; the emission itself is asserted in webdriverEval.spec.
+      browser.execute.mockResolvedValueOnce([{ level: 'warn', args: ['from teardown'] }]);
       const callsBefore = browser.execute.mock.calls.length;
       await service.after();
-      expect(browser.execute.mock.calls.length).toBeGreaterThan(callsBefore);
+
+      const drainCall = browser.execute.mock.calls.slice(callsBefore).find((c) => String(c[0]).includes('return l'));
+      expect(drainCall).toBeDefined();
     });
 
     it('should reap the WebKitGTK app tree on Linux teardown (unblocks deleteSession)', async () => {

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -426,6 +426,27 @@ describe('ElectrobunWorkerService', () => {
       expect(browser.switchToWindow).toHaveBeenCalledWith('h1');
     });
 
+    it('should reject switchWindow for an unrecognised label (not silently target main)', async () => {
+      const browser = makeW3CBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      await expect((browser as unknown as Installed).electrobun.switchWindow('typo')).rejects.toThrow(
+        /unrecognised window label/,
+      );
+      expect(browser.switchToWindow).not.toHaveBeenCalled();
+    });
+
+    it('should preserve undefined from execute (WebDriver would surface it as null)', async () => {
+      const browser = makeW3CBrowser();
+      browser.executeAsync.mockResolvedValue({ ok: true, undef: true });
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      const result = await (browser as unknown as Installed).electrobun.execute(() => undefined);
+      expect(result).toBeUndefined();
+    });
+
     it('should install the console shim and drain it on teardown', async () => {
       const browser = makeW3CBrowser();
       const service = new ElectrobunWorkerService({}, {});

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -26,6 +26,10 @@ vi.mock('@wdio/native-cdp-bridge', () => ({
   },
 }));
 
+// Mock execFileSync so the Linux app-reap (pkill) can be asserted without spawning anything.
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }));
+
 // Keep the real WebDriverEvalBridge + installConsoleShim; stub the factory so tests inject a
 // poster instead of doing raw /execute/async HTTP.
 vi.mock('../src/webdriverEval.js', async (importOriginal) => {
@@ -471,6 +475,53 @@ describe('ElectrobunWorkerService', () => {
       await service.after();
       // Drain evaluates once more to read + clear the buffer.
       expect(browser.execute.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('should reap the WebKitGTK app tree on Linux teardown (unblocks deleteSession)', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      try {
+        const browser = makeW3CBrowser();
+        // A realistic, specific bundle path (the reap guards against too-generic paths like /app).
+        const cap = {
+          'webkitgtk:browserOptions': {
+            binary: '/home/runner/build/WDIOElectrobunE2E-dev/bin/launcher',
+            args: ['--automation'],
+          },
+        };
+        const service = new ElectrobunWorkerService({}, {});
+        await service.before(cap, [], browser);
+        execFileSyncMock.mockClear();
+
+        await service.after();
+
+        // pkill matches the app bundle root so WDIO's subsequent deleteSession returns fast.
+        expect(execFileSyncMock).toHaveBeenCalledWith(
+          'pkill',
+          ['-9', '-f', '/home/runner/build/WDIOElectrobunE2E-dev'],
+          expect.anything(),
+        );
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      }
+    });
+
+    it('should NOT reap for a too-generic bundle path (safety guard)', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      try {
+        const browser = makeW3CBrowser();
+        // binary '/app/bin/launcher' -> bundle root '/app' (too short) -> skipped.
+        const service = new ElectrobunWorkerService({}, {});
+        await service.before(w3cCap, [], browser);
+        execFileSyncMock.mockClear();
+
+        await service.after();
+
+        expect(execFileSyncMock).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      }
     });
 
     it('should create a mock over the W3C eval channel', async () => {

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -26,8 +26,16 @@ vi.mock('@wdio/native-cdp-bridge', () => ({
   },
 }));
 
+// Keep the real WebDriverEvalBridge + installConsoleShim; stub the factory so tests inject a
+// poster instead of doing raw /execute/async HTTP.
+vi.mock('../src/webdriverEval.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/webdriverEval.js')>();
+  return { ...actual, createWebDriverEvalBridge: vi.fn() };
+});
+
 import type { ElectrobunServiceAPI } from '@wdio/native-types';
 import ElectrobunWorkerService from '../src/service.js';
+import { createWebDriverEvalBridge, WebDriverEvalBridge } from '../src/webdriverEval.js';
 
 type Installed = { electrobun: ElectrobunServiceAPI };
 
@@ -360,23 +368,24 @@ describe('ElectrobunWorkerService', () => {
   describe('W3C (WebKitGTK) mode', () => {
     const w3cCap = { 'webkitgtk:browserOptions': { binary: '/app/bin/launcher', args: ['--automation'] } };
 
-    function makeW3CBrowser(): WebdriverIO.Browser & {
-      executeAsync: ReturnType<typeof vi.fn>;
-      execute: ReturnType<typeof vi.fn>;
-    } {
+    // The raw /execute/async poster the WebDriverEvalBridge calls; returns a W3C `{ value }`.
+    let poster: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      poster = vi.fn().mockResolvedValue({ value: { ok: true, value: undefined } });
+      vi.mocked(createWebDriverEvalBridge).mockImplementation(() => new WebDriverEvalBridge(poster));
+    });
+
+    function makeW3CBrowser(): WebdriverIO.Browser & { execute: ReturnType<typeof vi.fn> } {
       return {
         isMultiremote: false,
         sessionId: 'w3c',
+        options: { protocol: 'http', hostname: '127.0.0.1', port: 9333 },
         // execute (sync) backs the console shim install + drain; return [] so drain is a no-op.
         execute: vi.fn().mockResolvedValue([]),
-        // executeAsync backs the W3C eval channel (execute + mock).
-        executeAsync: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
         getWindowHandles: vi.fn().mockResolvedValue(['h0', 'h1']),
         switchToWindow: vi.fn().mockResolvedValue(undefined),
-      } as unknown as WebdriverIO.Browser & {
-        executeAsync: ReturnType<typeof vi.fn>;
-        execute: ReturnType<typeof vi.fn>;
-      };
+      } as unknown as WebdriverIO.Browser & { execute: ReturnType<typeof vi.fn> };
     }
 
     it('should install browser.electrobun over W3C without a CDP bridge', async () => {
@@ -393,25 +402,27 @@ describe('ElectrobunWorkerService', () => {
       }
     });
 
-    it('should run execute over browser.executeAsync (W3C eval channel)', async () => {
+    it('should run execute over the raw /execute/async poster (W3C eval channel)', async () => {
       const browser = makeW3CBrowser();
-      browser.executeAsync.mockResolvedValue({ ok: true, value: 7 });
+      poster.mockResolvedValue({ value: { ok: true, value: 7 } });
       const service = new ElectrobunWorkerService({}, {});
       await service.before(w3cCap, [], browser);
 
       const result = await (browser as unknown as Installed).electrobun.execute(() => 7);
 
       expect(result).toBe(7);
-      expect(browser.executeAsync).toHaveBeenCalled();
+      expect(poster).toHaveBeenCalled();
     });
 
-    it('should surface a page-level error from execute', async () => {
+    it('should surface a page-level error message from execute', async () => {
       const browser = makeW3CBrowser();
-      browser.executeAsync.mockResolvedValue({ ok: false, error: 'ReferenceError: boom' });
+      poster.mockResolvedValue({ value: { ok: false, error: 'Test error from execute' } });
       const service = new ElectrobunWorkerService({}, {});
       await service.before(w3cCap, [], browser);
 
-      await expect((browser as unknown as Installed).electrobun.execute(() => 1)).rejects.toThrow(/boom/);
+      await expect((browser as unknown as Installed).electrobun.execute(() => 1)).rejects.toThrow(
+        /Test error from execute/,
+      );
     });
 
     it('should list and switch windows via W3C handles', async () => {
@@ -439,7 +450,7 @@ describe('ElectrobunWorkerService', () => {
 
     it('should preserve undefined from execute (WebDriver would surface it as null)', async () => {
       const browser = makeW3CBrowser();
-      browser.executeAsync.mockResolvedValue({ ok: true, undef: true });
+      poster.mockResolvedValue({ value: { ok: true, undef: true } });
       const service = new ElectrobunWorkerService({}, {});
       await service.before(w3cCap, [], browser);
 
@@ -470,8 +481,8 @@ describe('ElectrobunWorkerService', () => {
       const mock = await (browser as unknown as Installed).electrobun.mock('api.fetchData');
 
       expect(mock).toBeDefined();
-      // The inner-recorder install script ran over W3C (executeAsync), not a CDP bridge.
-      expect(browser.executeAsync).toHaveBeenCalled();
+      // The inner-recorder install script ran over the raw /execute/async poster, not a CDP bridge.
+      expect(poster).toHaveBeenCalled();
       expect(cdpBridgeCtor).not.toHaveBeenCalled();
     });
   });

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -356,4 +356,102 @@ describe('ElectrobunWorkerService', () => {
       expect((instanceB as unknown as Partial<Installed>).electrobun).toBeDefined();
     });
   });
+
+  describe('W3C (WebKitGTK) mode', () => {
+    const w3cCap = { 'webkitgtk:browserOptions': { binary: '/app/bin/launcher', args: ['--automation'] } };
+
+    function makeW3CBrowser(): WebdriverIO.Browser & {
+      executeAsync: ReturnType<typeof vi.fn>;
+      execute: ReturnType<typeof vi.fn>;
+    } {
+      return {
+        isMultiremote: false,
+        sessionId: 'w3c',
+        // execute (sync) backs the console shim install + drain; return [] so drain is a no-op.
+        execute: vi.fn().mockResolvedValue([]),
+        // executeAsync backs the W3C eval channel (execute + mock).
+        executeAsync: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+        getWindowHandles: vi.fn().mockResolvedValue(['h0', 'h1']),
+        switchToWindow: vi.fn().mockResolvedValue(undefined),
+      } as unknown as WebdriverIO.Browser & {
+        executeAsync: ReturnType<typeof vi.fn>;
+        execute: ReturnType<typeof vi.fn>;
+      };
+    }
+
+    it('should install browser.electrobun over W3C without a CDP bridge', async () => {
+      const browser = makeW3CBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+
+      await service.before(w3cCap, [], browser);
+
+      expect(cdpBridgeCtor).not.toHaveBeenCalled();
+      const { electrobun } = browser as unknown as Installed;
+      expect(electrobun).toBeDefined();
+      for (const name of ['execute', 'mock', 'switchWindow', 'listWindows', 'clearAllMocks']) {
+        expect(typeof (electrobun as unknown as Record<string, unknown>)[name]).toBe('function');
+      }
+    });
+
+    it('should run execute over browser.executeAsync (W3C eval channel)', async () => {
+      const browser = makeW3CBrowser();
+      browser.executeAsync.mockResolvedValue({ ok: true, value: 7 });
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      const result = await (browser as unknown as Installed).electrobun.execute(() => 7);
+
+      expect(result).toBe(7);
+      expect(browser.executeAsync).toHaveBeenCalled();
+    });
+
+    it('should surface a page-level error from execute', async () => {
+      const browser = makeW3CBrowser();
+      browser.executeAsync.mockResolvedValue({ ok: false, error: 'ReferenceError: boom' });
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      await expect((browser as unknown as Installed).electrobun.execute(() => 1)).rejects.toThrow(/boom/);
+    });
+
+    it('should list and switch windows via W3C handles', async () => {
+      const browser = makeW3CBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      const windows = await (browser as unknown as Installed).electrobun.listWindows();
+      expect(windows).toEqual(['main', 'window-1']);
+
+      await (browser as unknown as Installed).electrobun.switchWindow('window-1');
+      expect(browser.switchToWindow).toHaveBeenCalledWith('h1');
+    });
+
+    it('should install the console shim and drain it on teardown', async () => {
+      const browser = makeW3CBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      // The shim install script runs during before().
+      const installed = browser.execute.mock.calls.some((c) => String(c[0]).includes('__WDIO_ELECTROBUN_LOGS__'));
+      expect(installed).toBe(true);
+
+      const callsBefore = browser.execute.mock.calls.length;
+      await service.after();
+      // Drain evaluates once more to read + clear the buffer.
+      expect(browser.execute.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('should create a mock over the W3C eval channel', async () => {
+      const browser = makeW3CBrowser();
+      const service = new ElectrobunWorkerService({}, {});
+      await service.before(w3cCap, [], browser);
+
+      const mock = await (browser as unknown as Installed).electrobun.mock('api.fetchData');
+
+      expect(mock).toBeDefined();
+      // The inner-recorder install script ran over W3C (executeAsync), not a CDP bridge.
+      expect(browser.executeAsync).toHaveBeenCalled();
+      expect(cdpBridgeCtor).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/electrobun-service/test/service.spec.ts
+++ b/packages/electrobun-service/test/service.spec.ts
@@ -26,7 +26,6 @@ vi.mock('@wdio/native-cdp-bridge', () => ({
   },
 }));
 
-// Mock execFileSync so the Linux app-reap (pkill) can be asserted without spawning anything.
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }));
 
@@ -372,7 +371,6 @@ describe('ElectrobunWorkerService', () => {
   describe('W3C (WebKitGTK) mode', () => {
     const w3cCap = { 'webkitgtk:browserOptions': { binary: '/app/bin/launcher', args: ['--automation'] } };
 
-    // The raw /execute/async poster the WebDriverEvalBridge calls; returns a W3C `{ value }`.
     let poster: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
@@ -385,7 +383,6 @@ describe('ElectrobunWorkerService', () => {
         isMultiremote: false,
         sessionId: 'w3c',
         options: { protocol: 'http', hostname: '127.0.0.1', port: 9333 },
-        // execute (sync) backs the console shim install + drain; return [] so drain is a no-op.
         execute: vi.fn().mockResolvedValue([]),
         getWindowHandles: vi.fn().mockResolvedValue(['h0', 'h1']),
         switchToWindow: vi.fn().mockResolvedValue(undefined),
@@ -467,13 +464,11 @@ describe('ElectrobunWorkerService', () => {
       const service = new ElectrobunWorkerService({}, {});
       await service.before(w3cCap, [], browser);
 
-      // The shim install script runs during before().
       const installed = browser.execute.mock.calls.some((c) => String(c[0]).includes('__WDIO_ELECTROBUN_LOGS__'));
       expect(installed).toBe(true);
 
       const callsBefore = browser.execute.mock.calls.length;
       await service.after();
-      // Drain evaluates once more to read + clear the buffer.
       expect(browser.execute.mock.calls.length).toBeGreaterThan(callsBefore);
     });
 
@@ -482,7 +477,6 @@ describe('ElectrobunWorkerService', () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
       try {
         const browser = makeW3CBrowser();
-        // A realistic, specific bundle path (the reap guards against too-generic paths like /app).
         const cap = {
           'webkitgtk:browserOptions': {
             binary: '/home/runner/build/WDIOElectrobunE2E-dev/bin/launcher',
@@ -495,8 +489,6 @@ describe('ElectrobunWorkerService', () => {
 
         await service.after();
 
-        // pkill matches the app bundle root (escaped + anchored to argv0) so WDIO's subsequent
-        // deleteSession returns fast without risking unrelated processes.
         expect(execFileSyncMock).toHaveBeenCalledWith(
           'pkill',
           ['-9', '-f', '^/home/runner/build/WDIOElectrobunE2E-dev/'],
@@ -521,7 +513,6 @@ describe('ElectrobunWorkerService', () => {
 
         await service.after();
 
-        // `.` and `+` are escaped; anchored to argv0 under the bundle dir.
         expect(execFileSyncMock).toHaveBeenCalledWith(
           'pkill',
           ['-9', '-f', '^/home/runner/b/My\\.App\\+v2/'],
@@ -537,7 +528,6 @@ describe('ElectrobunWorkerService', () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
       try {
         const browser = makeW3CBrowser();
-        // binary '/app/bin/launcher' -> bundle root '/app' (too short) -> skipped.
         const service = new ElectrobunWorkerService({}, {});
         await service.before(w3cCap, [], browser);
         execFileSyncMock.mockClear();
@@ -558,7 +548,6 @@ describe('ElectrobunWorkerService', () => {
       const mock = await (browser as unknown as Installed).electrobun.mock('api.fetchData');
 
       expect(mock).toBeDefined();
-      // The inner-recorder install script ran over the raw /execute/async poster, not a CDP bridge.
       expect(poster).toHaveBeenCalled();
       expect(cdpBridgeCtor).not.toHaveBeenCalled();
     });

--- a/packages/electrobun-service/test/transport.spec.ts
+++ b/packages/electrobun-service/test/transport.spec.ts
@@ -39,9 +39,18 @@ describe('resolveTransport', () => {
     expect(resolveTransport(app('native-cefless'), 'win32')).toBe('webview2');
   });
 
-  it('should return undefined on Linux (WebKitGTK exposes no CDP) and any other platform', () => {
+  it('should return webkitgtk on Linux for the native renderer (W3C WebDriver)', () => {
+    expect(resolveTransport(app('native'), 'linux')).toBe('webkitgtk');
+    expect(resolveTransport(app(undefined), 'linux')).toBe('webkitgtk');
+    expect(resolveTransport(app(''), 'linux')).toBe('webkitgtk');
+  });
+
+  it('should return undefined on Linux for an explicit CEF build (CEF serves no /json there)', () => {
     expect(resolveTransport(app('cef'), 'linux')).toBeUndefined();
-    expect(resolveTransport(app('native'), 'linux')).toBeUndefined();
+  });
+
+  it('should return undefined on any other platform', () => {
+    expect(resolveTransport(app('native'), 'freebsd' as NodeJS.Platform)).toBeUndefined();
     expect(resolveTransport(app(undefined), 'freebsd' as NodeJS.Platform)).toBeUndefined();
   });
 });

--- a/packages/electrobun-service/test/webdriverEval.spec.ts
+++ b/packages/electrobun-service/test/webdriverEval.spec.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { WebDriverEvalBridge } from '../src/webdriverEval.js';
+const logSpies = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock('@wdio/native-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wdio/native-utils')>();
+  return { ...actual, createLogger: () => logSpies };
+});
+
+import { installConsoleShim, WebDriverEvalBridge } from '../src/webdriverEval.js';
 
 const bridge = (poster: (script: string) => Promise<{ value: unknown }>) => new WebDriverEvalBridge(poster);
 
@@ -42,5 +53,53 @@ describe('WebDriverEvalBridge', () => {
     await expect(
       bridge(vi.fn()).send('Page.navigate', { expression: '' } as unknown as { expression: string }),
     ).rejects.toThrow(/Runtime\.evaluate/);
+  });
+});
+
+describe('installConsoleShim', () => {
+  it('should drain buffered console entries into the logger as [webview] lines at mapped levels', async () => {
+    for (const spy of Object.values(logSpies)) {
+      spy.mockClear();
+    }
+    // The shim buffers { level, args } per entry; drain must forward each to the logger, mapping
+    // console levels to logger levels (unknown / 'log' → info) and prefixing '[webview]'.
+    const buffer = [
+      { level: 'log', args: ['hello', 'world'] },
+      { level: 'info', args: ['fyi'] },
+      { level: 'warn', args: ['careful'] },
+      { level: 'error', args: ['boom'] },
+      { level: 'debug', args: ['trace-me'] },
+      { level: 'weird', args: ['fallback'] },
+    ];
+    const execute = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(buffer);
+    const browser = { execute } as unknown as WebdriverIO.Browser;
+
+    const drain = await installConsoleShim(browser);
+    await drain();
+
+    expect(logSpies.info).toHaveBeenCalledWith('[webview] hello world');
+    expect(logSpies.info).toHaveBeenCalledWith('[webview] fyi');
+    expect(logSpies.info).toHaveBeenCalledWith('[webview] fallback');
+    expect(logSpies.warn).toHaveBeenCalledWith('[webview] careful');
+    expect(logSpies.error).toHaveBeenCalledWith('[webview] boom');
+    expect(logSpies.debug).toHaveBeenCalledWith('[webview] trace-me');
+
+    // Drain reads and clears the per-document buffer.
+    expect(String(execute.mock.calls[1][0])).toContain('window.__WDIO_ELECTROBUN_LOGS__ = []');
+  });
+
+  it('should emit nothing when the buffer is empty', async () => {
+    for (const spy of Object.values(logSpies)) {
+      spy.mockClear();
+    }
+    const execute = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce([]);
+    const browser = { execute } as unknown as WebdriverIO.Browser;
+
+    const drain = await installConsoleShim(browser);
+    await drain();
+
+    for (const spy of Object.values(logSpies)) {
+      expect(spy).not.toHaveBeenCalled();
+    }
   });
 });

--- a/packages/electrobun-service/test/webdriverEval.spec.ts
+++ b/packages/electrobun-service/test/webdriverEval.spec.ts
@@ -32,7 +32,6 @@ describe('WebDriverEvalBridge', () => {
     const poster = vi.fn().mockResolvedValue({ value: { ok: true, value: 1 } });
     await bridge(poster).send('Runtime.evaluate', { expression: 'doThing()' });
     const script = poster.mock.calls[0][0] as string;
-    // Callback is the injected last arg; the user expression is inlined; done is always called.
     expect(script).toContain('arguments[arguments.length - 1]');
     expect(script).toContain('(doThing())');
     expect(script).toContain('done({ ok: true');

--- a/packages/electrobun-service/test/webdriverEval.spec.ts
+++ b/packages/electrobun-service/test/webdriverEval.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { WebDriverEvalBridge } from '../src/webdriverEval.js';
+
+const bridge = (poster: (script: string) => Promise<{ value: unknown }>) => new WebDriverEvalBridge(poster);
+
+describe('WebDriverEvalBridge', () => {
+  it('should map a resolved outcome to result.value', async () => {
+    const b = bridge(vi.fn().mockResolvedValue({ value: { ok: true, value: 42 } }));
+    expect(await b.send('Runtime.evaluate', { expression: '1' })).toEqual({ result: { value: 42 } });
+  });
+
+  it('should preserve a genuine undefined (undef flag) rather than null', async () => {
+    const b = bridge(vi.fn().mockResolvedValue({ value: { ok: true, undef: true } }));
+    expect(await b.send('Runtime.evaluate', { expression: '1' })).toEqual({ result: { value: undefined } });
+  });
+
+  it('should map a caught page error to exceptionDetails carrying the message', async () => {
+    const b = bridge(vi.fn().mockResolvedValue({ value: { ok: false, error: 'Test error from execute' } }));
+    const response = await b.send('Runtime.evaluate', { expression: '1' });
+    expect(response.exceptionDetails?.exception?.description).toBe('Test error from execute');
+    expect(response.result).toBeUndefined();
+  });
+
+  it('should map a raw W3C error response (no ok field) via its message', async () => {
+    const b = bridge(vi.fn().mockResolvedValue({ value: { error: 'javascript error', message: 'MsgSync' } }));
+    const response = await b.send('Runtime.evaluate', { expression: '1' });
+    expect(response.exceptionDetails?.exception?.description).toBe('MsgSync');
+  });
+
+  it('should wrap the expression in a try/catch → done protocol script', async () => {
+    const poster = vi.fn().mockResolvedValue({ value: { ok: true, value: 1 } });
+    await bridge(poster).send('Runtime.evaluate', { expression: 'doThing()' });
+    const script = poster.mock.calls[0][0] as string;
+    // Callback is the injected last arg; the user expression is inlined; done is always called.
+    expect(script).toContain('arguments[arguments.length - 1]');
+    expect(script).toContain('(doThing())');
+    expect(script).toContain('done({ ok: true');
+    expect(script).toContain('done({ ok: false');
+  });
+
+  it('should reject a non-Runtime.evaluate method (wiring bug)', async () => {
+    await expect(
+      bridge(vi.fn()).send('Page.navigate', { expression: '' } as unknown as { expression: string }),
+    ).rejects.toThrow(/Runtime\.evaluate/);
+  });
+});

--- a/packages/electrobun-service/test/webkitDriver.spec.ts
+++ b/packages/electrobun-service/test/webkitDriver.spec.ts
@@ -1,0 +1,67 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getWebKitWebDriverPath, waitForWebKitWebDriverReady, webKitWebDriverArgs } from '../src/webkitDriver.js';
+
+vi.mock('node:child_process', () => ({ execSync: vi.fn(), spawn: vi.fn() }));
+vi.mock('node:fs', () => ({ existsSync: vi.fn() }));
+
+const mockedExecSync = vi.mocked(execSync);
+const mockedExistsSync = vi.mocked(existsSync);
+
+describe('getWebKitWebDriverPath', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return undefined on non-Linux platforms without probing', () => {
+    expect(getWebKitWebDriverPath('darwin')).toBeUndefined();
+    expect(getWebKitWebDriverPath('win32')).toBeUndefined();
+    expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it('should return the PATH match from `which` when it exists', () => {
+    mockedExecSync.mockReturnValue('/usr/bin/WebKitWebDriver\n');
+    mockedExistsSync.mockImplementation((p) => p === '/usr/bin/WebKitWebDriver');
+    expect(getWebKitWebDriverPath('linux')).toBe('/usr/bin/WebKitWebDriver');
+  });
+
+  it('should fall back to common paths when not on PATH', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    mockedExistsSync.mockImplementation((p) => p === '/usr/lib/webkit2gtk-4.1/WebKitWebDriver');
+    expect(getWebKitWebDriverPath('linux')).toBe('/usr/lib/webkit2gtk-4.1/WebKitWebDriver');
+  });
+
+  it('should return undefined when WebKitWebDriver is not found anywhere', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    mockedExistsSync.mockReturnValue(false);
+    expect(getWebKitWebDriverPath('linux')).toBeUndefined();
+  });
+});
+
+describe('webKitWebDriverArgs', () => {
+  it('should use equals-form flags (space-form makes WebKitWebDriver print usage and exit)', () => {
+    expect(webKitWebDriverArgs('127.0.0.1', 4444)).toEqual(['--host=127.0.0.1', '--port=4444']);
+  });
+});
+
+describe('waitForWebKitWebDriverReady', () => {
+  it('should resolve once /status returns a value', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: { ready: true, message: 'ok' } }),
+    }) as unknown as typeof fetch;
+    await expect(waitForWebKitWebDriverReady('127.0.0.1', 4444, 1000, fetchImpl)).resolves.toBeUndefined();
+  });
+
+  it('should throw when /status never becomes ready within the timeout', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    await expect(waitForWebKitWebDriverReady('127.0.0.1', 4444, 10, fetchImpl)).rejects.toThrow(/did not become ready/);
+  });
+});

--- a/packages/native-utils/src/log.ts
+++ b/packages/native-utils/src/log.ts
@@ -6,6 +6,7 @@ export type LogArea =
   | 'launcher'
   | 'session'
   | 'bridge'
+  | 'driver'
   | 'mock'
   | 'bundler'
   | 'config'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
   fixtures/e2e-apps/electrobun:
     dependencies:
       electrobun:
-        specifier: 1.18.1
-        version: 1.18.1(supports-color@8.1.1)
+        specifier: 2.0.1
+        version: 2.0.1
     devDependencies:
       '@types/bun':
         specifier: 1.3.14
@@ -5116,6 +5116,11 @@ packages:
 
   electrobun@1.18.1:
     resolution: {integrity: sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA==}
+    hasBin: true
+
+  electrobun@2.0.1:
+    resolution: {integrity: sha512-1+OjJ0tMemjVrUEsh/AhmxnqUNpyCfJslCbcWOvkogFJuNVMmTlWMzyZem/Ts/7lg8f7ULWu8uuQBsKeGQsu7A==}
+    engines: {node: '>=18'}
     hasBin: true
 
   electron-builder-squirrel-windows@26.15.3:
@@ -12863,6 +12868,8 @@ snapshots:
       three: 0.165.0
     transitivePeerDependencies:
       - supports-color
+
+  electrobun@2.0.1: {}
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
## Summary

Adds **Linux support** to `@wdio/electrobun-service`, driving the native **WebKitGTK** renderer over **W3C WebDriver** (`WebKitWebDriver`) — the non-CEF track's remaining renderer. This completes #317 (Windows/WebView2 already shipped; macOS-native WKWebView is deferred to #629). It also cuts the e2e fixture over to **electrobun 2.0.1**, which exposes WebKitGTK automation upstream ([blackboardsh/electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)).

Unblocked by **electrobun 2.0.1** — see the two throwaway spikes that de-risked this end-to-end before implementation:
- **Spike 1** (generic mechanism, 4/4): execute + native-spy mock + console shim over `WebKitWebDriver`/JavaScriptCore.
- **Spike 2** (the real fixture, 5/5): the actual e2e app built Linux-native on 2.0.1, driven via `bin/launcher --automation` — automation attached to the app's own view; execute/mock/console-shim all green.

## Design

- **No Rust intermediary.** Unlike `tauri-driver`/`wdio-dioxus-driver` (which exist only because Wry never exposed an automation toggle), electrobun 2.0.1 exposes WebKitGTK automation upstream — so the service spawns **`WebKitWebDriver` directly** (reusing `@wdio/native-core`'s `DriverProcess`-style spawn) and passes `webkitgtk:browserOptions: { binary: <app>/bin/launcher, args: ['--automation'] }`, deleting `browserName` and forcing classic W3C.
- **Zero divergence from the CDP surface.** The worker installs `browser.electrobun.*` over W3C through a small `WebDriverEvalBridge` adapter (a `send('Runtime.evaluate', …)` shim backed by `browser.executeAsync`), so the **entire CDP `execute` + `mock` + inner-recorder machinery is reused verbatim** — not a parallel implementation.
- **Frontend log capture** via an injected `console.*` shim (buffered in-page, drained to the logger), supplemented by the driver's stdout (electrobun forwards `console.*` there).
- **`xvfb-run -a`** wrap of the launcher-spawned driver on Linux (autoXvfb covers only the worker process, not launcher-spawned processes — mirrors the CEF app wrap in `nativeMode.ts`).

## What's in the box

| Area | |
|---|---|
| Transport + driver | `webkitgtk` transport, `WebKitWebDriver` discovery/spawn/readiness/stop, install-hint error |
| Launcher | Linux guard lifted; W3C caps; per-worker driver spawn + teardown |
| Worker | `WebDriverEvalBridge` (execute/mock reuse), console shim, W3C window handles |
| Fixture | electrobun `1.18.1 → 2.0.1` + Linux `native` renderer |
| Docs | README **OS × renderer automation coverage matrix** (supported + unsupported) |
| CI | Non-gating Linux build + e2e legs; `webkit2gtk-driver` install |

**222 unit tests green**, typecheck + YAML clean. A high-effort code review ran against the branch; all findings were addressed (incl. a real headless-CI xvfb bug caught before it ran) — the one "delete browserName may break New Session" flag was refuted by Spike 2's no-browserName New Session.

## Validation status ✅

**Green on CI across macOS (CEF), Windows (WebView2), and Linux (WebKitGTK).** The Linux leg is **gating** (in `ci-status.needs`), proven green across 3 consecutive runs. The 2.0.1 cutover held on all platforms (the macOS CEF `browserVersion: 147` pin is still correct; ChromeDriver 147 matched). Each fix below was verified with a Docker repro against the real app before re-pushing:

- **execute** over raw `/execute/async` — WDIO's `executeAsync` wraps the script and surfaces a page throw as a `WebDriverError` carrying the JSC stack (no message); the raw endpoint honours our in-page `try/catch → done` protocol and returns a clean message.
- **teardown** — single-window Linux fixture + detached-spawn/group-kill + an app-tree reap in the worker `after` hook: WebKitWebDriver can't cleanly close the controlled webview, so `DELETE /session` otherwise hangs ~120s.
- **fail-fast New Session** (Linux 45s) for the rare intermittent app-launch hang, so a spec-file retry re-spawns cheaply.
- **logging** — backend-log capture skipped on Linux (`captureBackendLogs` is CDP-only).

Scoped-out on Linux (documented in the README): single-window only (`switchWindow`/`listWindows` best-effort), no `triggerDeeplink` (upstream), no structured `captureBackendLogs`.

> The DELETE-session hang is an upstream electrobun limitation (the automation session isn't cleanly closeable); the app-tree reap is the service-side workaround. An upstream issue is pending.

Closes #317. Related: #320 (CEF track, still upstream-blocked), #629 (macOS-native, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
