### PR TITLE
refactor(tauri): fire-and-forget evaluateJavaScript for macOS DirectEval (#569)

### DIFF
--- a/packages/tauri-plugin-webdriver/src/eval_channel.rs
+++ b/packages/tauri-plugin-webdriver/src/eval_channel.rs
@@ -6,13 +6,13 @@ use tokio::sync::oneshot;
 
 /// Correlates DirectEval results the webview reports back out-of-band, keyed by id.
 ///
-/// The macOS DirectEval path runs its script via `callAsyncJavaScript` to keep the run loop pumping
-/// (so the app's own `core.invoke` IPC resolves on a headless runner) but must NOT read the result
-/// from that call's completion handler — macOS 26.4's WebKit reclaims it intermittently. Instead the
-/// script posts `{ id, result }` to a `WKScriptMessageHandler`, which calls `complete` to wake the
-/// executor awaiting `register`. Mirrors the Windows `AsyncScriptState` native-handler pattern.
-/// Removable once the upstream reclaim is resolved:
-/// https://github.com/webdriverio/desktop-mobile/issues/540
+/// The macOS DirectEval path dispatches its script fire-and-forget via `evaluateJavaScript` (no
+/// completion handler) and takes the result solely from here: the script posts `{ id, result }` to a
+/// `WKScriptMessageHandler`, which calls `complete` to wake the executor awaiting `register`. The
+/// app's own `core.invoke` IPC is kept resolving on a headless runner by the standalone main run-loop
+/// pump (`start_runloop_pump`), not by holding a `callAsyncJavaScript` activity open — so there is no
+/// completion for macOS 26.x WebKit to reclaim. Mirrors the Windows `AsyncScriptState` native-handler
+/// pattern. https://github.com/webdriverio/desktop-mobile/issues/569
 #[derive(Default)]
 pub struct EvalResultRegistry {
     pending: Mutex<HashMap<String, oneshot::Sender<Value>>>,

--- a/packages/tauri-plugin-webdriver/src/platform/macos.rs
+++ b/packages/tauri-plugin-webdriver/src/platform/macos.rs
@@ -46,64 +46,6 @@ impl<R: Runtime> MacOSExecutor<R> {
             frame_context,
         }
     }
-
-    /// Dispatch one `callAsyncJavaScript` attempt of a DirectEval wrapper. The returned receiver fires
-    /// when macOS 26.4's WebKit reclaims the completion with no value — the signal `execute_direct_eval`
-    /// uses to re-dispatch. When the completion *does* carry a value, it is delivered to `registry` as a
-    /// fallback for a lost message-handler post (first-write-wins keeps the post authoritative).
-    fn dispatch_eval_attempt(
-        &self,
-        wrapper: &str,
-        id: &str,
-        registry: &Arc<EvalResultRegistry>,
-        attempt: usize,
-    ) -> Result<oneshot::Receiver<()>, String> {
-        let (fail_tx, fail_rx) = oneshot::channel::<()>();
-        let wrapper = wrapper.to_owned();
-        let id = id.to_owned();
-        let registry = registry.clone();
-        // `RcBlock` is `Fn` but `Sender::send` consumes self, so guard the one-shot send (WebKit calls
-        // the completion once; this just makes a double-call harmless). Same pattern as `evaluate_js`.
-        let fail_tx = Arc::new(std::sync::Mutex::new(Some(fail_tx)));
-
-        self.window
-            .with_webview(move |webview| unsafe {
-                let wk_webview: &WKWebView = &*webview.inner().cast();
-                let ns_script = NSString::from_str(&wrapper);
-                let mtm = MainThreadMarker::new_unchecked();
-                let empty_dict: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::new();
-                let content_world = WKContentWorld::pageWorld(mtm);
-
-                let block = RcBlock::new(move |result: *mut AnyObject, error: *mut NSError| {
-                    if !error.is_null() {
-                        tracing::debug!(
-                            "DirectEval completion reclaimed (attempt {attempt}): {}",
-                            describe_ns_error(&*error)
-                        );
-                        if let Ok(mut guard) = fail_tx.lock() {
-                            if let Some(tx) = guard.take() {
-                                let _ = tx.send(());
-                            }
-                        }
-                        return;
-                    }
-                    if !result.is_null() {
-                        registry.complete(&id, ns_object_to_json(&*result));
-                    }
-                });
-
-                wk_webview.callAsyncJavaScript_arguments_inFrame_inContentWorld_completionHandler(
-                    &ns_script,
-                    Some(&empty_dict),
-                    None,
-                    &content_world,
-                    Some(&block),
-                );
-            })
-            .map_err(|e| e.to_string())?;
-
-        Ok(fail_rx)
-    }
 }
 
 /// Register `WKWebView` handlers at webview creation time.
@@ -360,29 +302,26 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
         }
     }
 
-    /// DirectEval (`/wdio/eval`) with out-of-band result delivery + reclaim recovery.
+    /// DirectEval (`/wdio/eval`) with out-of-band result delivery.
     ///
-    /// Each attempt is dispatched by `dispatch_eval_attempt` via `callAsyncJavaScript`, which keeps the
-    /// run loop pumping — on a headless runner the app's own `core.invoke` IPC response only completes
-    /// while WebKit holds a run-loop activity. The result is delivered primarily out-of-band: the
-    /// wrapper posts `{ id, result }` to the `wdioEvalResult` `WKScriptMessageHandler`, which completes
-    /// the `oneshot` awaited here. macOS 26.4's WebKit intermittently reclaims the `callAsyncJavaScript`
-    /// completion ("Completion handler for function call is no longer reachable"); usually the post
-    /// still lands, but sometimes the script never posts and this would otherwise dead-wait to the
-    /// script timeout (#540 residual). Two guards recover it without changing the happy path:
-    ///   1. **Fallback delivery** — when the completion *does* fire with a value, `dispatch_eval_attempt`
-    ///      hands it to the same registry (first-write-wins keeps the post authoritative), so a lost
-    ///      post resolves instead of dead-waiting.
-    ///   2. **Bounded re-dispatch** — when the completion is reclaimed with *no* value and no post lands
-    ///      within `RECLAIM_GRACE`, re-run the script (up to `MAX_ATTEMPTS`). The grace lets a racing
-    ///      post settle first; a genuine re-dispatch *re-executes* the script, so a non-idempotent eval
-    ///      could double-apply — acceptable for the read-style evals `execute` runs in practice.
-    /// The whole sequence is bounded by `deadline`. Mirrors the Windows native-handler path
-    /// (`AsyncScriptState`). https://github.com/webdriverio/desktop-mobile/issues/540
+    /// Dispatched fire-and-forget via `evaluateJavaScript` with **no** completion handler: the wrapper's
+    /// synchronous prefix kicks off the script (e.g. the app's own `core.invoke` IPC) and registers
+    /// `__report`, then returns immediately. The result is delivered purely out-of-band — `__report`
+    /// posts `{ id, result }` to the `wdioEvalResult` `WKScriptMessageHandler`, which completes the
+    /// `oneshot` awaited here. On a headless runner the app's main run loop would otherwise park and
+    /// `core.invoke` would never resolve; the standalone `NSTimer` pump (`start_runloop_pump`) services
+    /// the loop instead, so no held-open `callAsyncJavaScript` activity is needed to keep it turning.
+    ///
+    /// Because nothing holds the completion open, macOS 26.x's WebKit has no completion to reclaim
+    /// ("Completion handler for function call is no longer reachable"), which is what previously forced
+    /// the retry/fallback/grace machinery here — and, with it, the re-execution (double-apply) hazard.
+    /// This path has no retry, so a script (and any mocks it hits) runs exactly once. Mirrors the
+    /// Windows native-handler path (`AsyncScriptState`).
+    /// https://github.com/webdriverio/desktop-mobile/issues/569 (removes the #540/#553 machinery)
     ///
     /// `wrapScriptForDirectEval` produces a callback-style script (`arguments[last]` is its
-    /// done-callback); `__report` forwards the result to the message handler then `resolve`s so the
-    /// `callAsyncJavaScript` promise settles.
+    /// done-callback); `__report` forwards the result to the message handler. Unlike the old
+    /// `callAsyncJavaScript` path, there is no Promise to settle, so `__report` only posts.
     async fn execute_direct_eval(&self, script: &str) -> Result<Value, WebDriverErrorResponse> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -394,59 +333,52 @@ impl<R: Runtime + 'static> PlatformExecutor<R> for MacOSExecutor<R> {
             .state::<Arc<EvalResultRegistry>>()
             .inner()
             .clone();
-        let mut rx = registry.register(id.clone());
+        let rx = registry.register(id.clone());
 
         // id is alphanumeric + '_', so it needs no escaping in the JS string literal below.
+        // evaluateJavaScript runs this as a plain script (not a function body), so it must be an
+        // expression/statement, not `return ...`.
         let wrapper = format!(
-            r#"return new Promise((resolve) => {{
+            r#"(function () {{
   var __report = function (r) {{
     try {{ window.webkit.messageHandlers.wdioEvalResult.postMessage({{ id: "{id}", result: r }}); }} catch (e) {{}}
-    resolve(r);
   }};
   (function () {{ {script} }}).apply(null, [__report]);
-}});"#
+}})();"#
         );
 
-        const MAX_ATTEMPTS: usize = 3;
-        // After a reclaim, wait this long for a racing message-handler post before re-running.
-        const RECLAIM_GRACE: std::time::Duration = std::time::Duration::from_millis(750);
-        let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_millis(self.timeouts.script_ms);
-        let channel_closed = || WebDriverErrorResponse::unknown_error("Eval result channel closed");
+        let dispatch = self.window.with_webview(move |webview| unsafe {
+            let wk_webview: &WKWebView = &*webview.inner().cast();
+            let ns_script = NSString::from_str(&wrapper);
+            // Fire-and-forget: passing no completion handler means WebKit holds nothing open to reclaim.
+            wk_webview.evaluateJavaScript_completionHandler(
+                &ns_script,
+                None::<&DynBlock<dyn Fn(*mut AnyObject, *mut NSError)>>,
+            );
+        });
 
-        // Retry only when WebKit reclaims the completion before a result was delivered; `timeout_at`
-        // bounds the whole sequence, so `Elapsed` (below) is the single script-timeout path.
-        let settled = tokio::time::timeout_at(deadline, async {
-            for attempt in 0..MAX_ATTEMPTS {
-                let fail_rx = self
-                    .dispatch_eval_attempt(&wrapper, &id, &registry, attempt)
-                    .map_err(|e| WebDriverErrorResponse::javascript_error(&e, None))?;
-                tokio::select! {
-                    r = &mut rx => return r.map_err(|_| channel_closed()),
-                    _ = fail_rx => {
-                        if attempt + 1 == MAX_ATTEMPTS {
-                            // Last attempt reclaimed: keep waiting for a late post until the deadline.
-                            return (&mut rx).await.map_err(|_| channel_closed());
-                        }
-                        // Race a late post against the grace: if the script actually ran and posts
-                        // here, return it — re-dispatching would execute the script (and any mocks it
-                        // hits) a second time. Only re-dispatch once the grace elapses with no result.
-                        tokio::select! {
-                            r = &mut rx => return r.map_err(|_| channel_closed()),
-                            _ = tokio::time::sleep(RECLAIM_GRACE) => {}
-                        }
-                    }
-                }
-            }
-            Err(WebDriverErrorResponse::script_timeout()) // unreachable: the final attempt returns above
-        })
-        .await;
-
-        let result = settled.unwrap_or_else(|_elapsed| Err(WebDriverErrorResponse::script_timeout()));
-        if result.is_err() {
+        if let Err(e) = dispatch {
             registry.cancel(&id);
+            return Err(WebDriverErrorResponse::javascript_error(
+                &e.to_string(),
+                None,
+            ));
         }
-        result
+
+        let timeout = std::time::Duration::from_millis(self.timeouts.script_ms);
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) => {
+                registry.cancel(&id);
+                Err(WebDriverErrorResponse::unknown_error(
+                    "Eval result channel closed",
+                ))
+            }
+            Err(_) => {
+                registry.cancel(&id);
+                Err(WebDriverErrorResponse::script_timeout())
+            }
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
## What

Implements #569: removes the macOS DirectEval reclaim-recovery machinery by switching from `callAsyncJavaScript` to **fire-and-forget `evaluateJavaScript`** + the standalone run-loop pump.

`execute_direct_eval` collapses to: register `rx` → dispatch fire-and-forget → `await rx` with a timeout. Deleted: `dispatch_eval_attempt` (the `callAsyncJavaScript` completion + fail signal), `MAX_ATTEMPTS`, `RECLAIM_GRACE`, the completion fallback-write, and the `timeout_at`/`select!` retry loop. Net −68 lines across `macos.rs` + `eval_channel.rs`.

## Why now

The machinery existed only because `callAsyncJavaScript` was chosen to pump the run loop on a headless runner, and macOS 26.x WebKit intermittently reclaims its held-open completion (*"Completion handler for function call is no longer reachable"*). #553 added a standalone `NSTimer` pump that services `core.invoke` independently — so `callAsyncJavaScript` is no longer needed to keep the loop turning:

- **No held-open completion ⇒ nothing to reclaim** ⇒ no retry/fallback/grace.
- **No retry ⇒ no double-execution** — the exact hazard that bit #553 when the grace collapsed and re-ran an already-run script (inflated mock call-counts). Structurally impossible now.

#549 previously tried fire-and-forget + poll and it *hung* — but that was **before** the `NSTimer` pump existed. The premise has changed; this is the piece that makes it viable.

## This is a verify-only experiment — CI is the adjudicator

The run-loop stall only reproduces on the headless runner (never locally, where a real display pumps the loop), so this stays **draft** until the macOS Tauri embedded legs are green across N runs. Watch:

- **`standalone` / `deeplink`** (embedded provider — the DirectEval path): a `Script execution timed out` means the pump alone cannot substitute for `callAsyncJavaScript`'s run-loop activity → the idea is dead, revert.
- **`mocking.spec` (standard leg)**: must pass (no double-execution).

Fire-and-forget has no fallback/retry to mask a stall — a pump failure times out hard — so a green run is trustworthy on its own.

> **Runner note:** the current `macos-26-arm64` image is macOS **26.5.2**, not the 26.4 the flake was characterized on. Per the re-framed #569, the gate is the headless run-loop stall (A), which is inherent to a displayless runner and independent of the 26.4-specific reclaim (B) — so this validation holds regardless of whether (B) still fires.

## Local checks
- `cargo check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (CI's Rust gate; `cargo fmt` is not enforced by CI)

Refs #540, #553. Closes #569 once green across N runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
