### PR TITLE
docs(electrobun): Linux WebKitGTK support + ADR-0005 (2.0-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is a monorepo providing WebdriverIO services for automated testing of nativ
 - **Electron** - `@wdio/electron-service` (v10.x)
 - **Tauri** - `@wdio/tauri-service` (v1.x)
 - **Dioxus** - `@wdio/dioxus-service` (v1.x)
-- **Electrobun** - `@wdio/electrobun-service` (v0.1.x — **macOS** via CEF + **Windows** via the native WebView2 renderer (CDP), incl. multi-window/multiremote; **Linux** upstream-blocked, and deeplink/multiremote blocked on the macOS CEF path — see the package README)
+- **Electrobun** - `@wdio/electrobun-service` (v0.1.x, **electrobun ≥ 2.0.1** — **macOS** via CEF + **Windows** via the native WebView2 renderer (CDP), incl. multi-window/multiremote + **Linux** via the native WebKitGTK renderer (W3C WebDriver, single-window); deeplink/multiremote on the macOS CEF path blocked upstream — see the package README)
 - **React Native** - `@wdio/react-native-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via Appium (UiAutomator2/XCUITest); `execute` + `mock` via Hermes CDP (debug/Metro build); full mock, deeplink, context switching, logs, parallel workers (multiremote not yet — see #446))
 - **Flutter** - `@wdio/flutter-service` (v1.0.0-next.x — **Android** + **iOS**; native find/tap via appium-flutter-driver (`FLUTTER` context); `execute` (Dart expression) + `mock` (Tier-2 cooperative `wdio_flutter` Dart contract) via the Dart VM Service (debug/profile build); full mock, deeplink, context switching, logs, parallel workers (multiremote not yet — see #446)). Built on `@wdio/native-mobile-core`.
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@
 
 > Early (`0.x`) support — feature surface is limited by upstream gaps. Not yet at parity with the services above.
 >
-> Electrobun: Linux upstream-blocked; macOS deeplink & multiremote upstream-blocked. [See README](./packages/electrobun-service)
+> Electrobun: macOS-CEF deeplink & multiremote upstream-blocked. [See README](./packages/electrobun-service)
 
 | Service | Version | Platforms | Downloads |
 |---|---|---|---|
-| [![@wdio/electrobun-service](https://img.shields.io/badge/@wdio-electrobun--service-ffffff?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/electrobun-service) | [![version](https://img.shields.io/npm/v/@wdio/electrobun-service)](https://www.npmjs.com/package/@wdio/electrobun-service) | macOS / Windows | [![downloads](https://img.shields.io/npm/dw/@wdio/electrobun-service)](https://www.npmjs.com/package/@wdio/electrobun-service) |
+| [![@wdio/electrobun-service](https://img.shields.io/badge/@wdio-electrobun--service-ffffff?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@wdio/electrobun-service) | [![version](https://img.shields.io/npm/v/@wdio/electrobun-service)](https://www.npmjs.com/package/@wdio/electrobun-service) | macOS / Windows / Linux | [![downloads](https://img.shields.io/npm/dw/@wdio/electrobun-service)](https://www.npmjs.com/package/@wdio/electrobun-service) |
 
 ## Planned Support
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,9 +40,9 @@ Published packages, grouped by release maturity. Status reflects the npm dist-ta
 > Feature surface limited by upstream gaps; not yet at parity with the services above.
 
 #### [@wdio/electrobun-service](./packages/electrobun-service) — v0.1.x
-**Platforms:** macOS 14+ (CEF), Windows 11+ (WebView2); Linux blocked upstream\
-**Highlights:** drives two renderers — **macOS via CEF** (CDP) and **Windows via the native WebView2** (Chromium over CDP, no CEF) — the latter also running the multi-window suite that CEF can't on CI.\
-**Caveats:** **Linux** blocked upstream (CEF serves no `/json`; the WebKitGTK renderer needs upstream W3C-WebDriver automation — [electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)); **deeplink on Windows** and **deeplink/multiremote on the macOS CEF path** are upstream-blocked. Each upstream fix re-enables a platform/feature, graduating toward `1.0` at full parity. Tracked in [#317](https://github.com/webdriverio/desktop-mobile/issues/317) (non-CEF) + [#320](https://github.com/webdriverio/desktop-mobile/issues/320) (CEF). See the [package README](./packages/electrobun-service).\
+**Platforms:** macOS 14+ (CEF), Windows 11+ (WebView2), Linux (WebKitGTK)\
+**Highlights:** drives three renderers — **macOS via CEF** (CDP), **Windows via the native WebView2** (Chromium over CDP, no CEF), and **Linux via the native WebKitGTK** (W3C WebDriver, electrobun ≥ 2.0.1, single-window); Windows also runs the multi-window suite that CEF can't on CI.\
+**Caveats:** **deeplink on Windows** and **deeplink/multiremote on the macOS CEF path** are upstream-blocked ([#320](https://github.com/webdriverio/desktop-mobile/issues/320)); macOS **WKWebView** has no automation surface, so a self-shipped embedded driver is deferred ([#629](https://github.com/webdriverio/desktop-mobile/issues/629)). Each upstream fix re-enables a feature, graduating toward `1.0` at full parity. See the [package README](./packages/electrobun-service).\
 [![npm downloads](https://img.shields.io/npm/dm/@wdio/electrobun-service)](https://npmjs.com/package/@wdio/electrobun-service)
 
 ---

--- a/docs/adr/0004-electrobun-cdp-under-cef.md
+++ b/docs/adr/0004-electrobun-cdp-under-cef.md
@@ -7,6 +7,10 @@ Date: 2026-08-03
 Accepted — retroactively documenting the Electrobun service architecture validated in the
 Phase-0 spike and shipped in [#314](https://github.com/webdriverio/desktop-mobile/pull/314).
 
+**Amended by [ADR-0005](./0005-electrobun-2-only-linux-webkitgtk.md)** — adopting Electrobun 2.0+
+adds a Linux WebKitGTK path over **W3C WebDriver**, so "the default WebKit renderer is unsupported"
+no longer holds universally (Linux only; macOS WKWebView still has no automation surface).
+
 ## Context
 
 An Electrobun app can render with either its **default WebKit renderer** or an opt-in **CEF**

--- a/docs/adr/0005-electrobun-2-only-linux-webkitgtk.md
+++ b/docs/adr/0005-electrobun-2-only-linux-webkitgtk.md
@@ -1,0 +1,65 @@
+# 5. Adopt Electrobun 2.0+ only, unlocking Linux WebKitGTK over W3C WebDriver
+
+Date: 2026-09-05
+
+## Status
+
+Accepted — shipped in [#631](https://github.com/webdriverio/desktop-mobile/pull/631). Amends
+[ADR-0004](./0004-electrobun-cdp-under-cef.md).
+
+## Context
+
+[ADR-0004](./0004-electrobun-cdp-under-cef.md) shipped Electrobun support on macOS (CEF) and
+Windows (WebView2), both driven over **CDP**, and deferred Linux as "blocked upstream": Electrobun
+1.x's default WebKitGTK renderer exposed no automation surface at all — no CDP endpoint, and no
+W3C-WebDriver path — so there was simply nothing to attach to on Linux.
+
+Electrobun **2.0** (a Bun→Zig core rewrite) changed that. Upstream
+[electrobun#467](https://github.com/blackboardsh/electrobun/issues/467) (shipped in 2.0.1) exposes
+WebKitGTK automation: an app opts in via `--automation` / `ELECTROBUN_WEBKIT_AUTOMATION`, and
+`WebKitWebDriver` then drives it over **W3C WebDriver**. Linux support is therefore only possible on
+2.0+ — 1.x cannot do it at all. **These are one decision, not two:** adopting 2.0 *is* what enables
+Linux.
+
+Electrobun is a new framework with effectively no users, and the users it does have track the latest
+release. Carrying 1.x compatibility would cost real complexity — two automation stories, version
+branching — for no one's benefit.
+
+## Decision
+
+Require **Electrobun 2.0+** and drop 1.x support. For a new, few-users framework we track the latest
+upstream release rather than maintain backward compatibility — the policy that makes the Linux path
+possible in the first place.
+
+Adopting 2.0 unlocks the **Linux WebKitGTK** transport, a **W3C-WebDriver** path that sits alongside
+the existing CDP-attach paths:
+
+- **macOS** — CEF over CDP (unchanged).
+- **Windows** — native WebView2 over CDP (unchanged).
+- **Linux** — native WebKitGTK over **W3C WebDriver**: `WebKitWebDriver` *launches* the app (via
+  `webkitgtk:browserOptions.binary` + `--automation`) and drives it. There is no CDP endpoint, and
+  the service does not spawn the app itself.
+
+This amends ADR-0004's "the default WebKit renderer is unsupported": the WebKit renderer is now
+supported on **Linux** via W3C. macOS **WKWebView** still exposes no automation surface and remains
+unsupported — a self-shipped embedded driver is tracked separately in
+[#629](https://github.com/webdriverio/desktop-mobile/issues/629).
+
+## Consequences
+
+- **Two transport families in one service.** CDP-attach (macOS/Windows — the service spawns the app
+  and a Chromedriver/msedgedriver attaches) and W3C (Linux — `WebKitWebDriver` launches the app).
+  The `execute` + `mock` machinery is reused over W3C via a small `Runtime.evaluate` adapter that
+  posts to `/execute/async` directly, because JSC surfaces page-level throws differently from
+  V8/CDP and WDIO's `executeAsync` wrapper mangles the message.
+- **Linux runtime specifics.** The service spawns `WebKitWebDriver` under `xvfb-run` on headless CI
+  and reaps the app tree on teardown — WebKitWebDriver can't cleanly close its controlled webview,
+  so `DELETE /session` otherwise hangs ~120s. Frontend logs come from an injected console shim (no
+  CDP console events); `captureBackendLogs` structured capture stays CDP-only.
+- **Single-window on Linux for now.** The automation session attaches to the primary app view;
+  multi-window / multiremote on Linux are deferred (a second window races the `create-web-view`
+  handshake under CI load).
+- **A hard `electrobun ≥ 2.0.1` floor.** The E2E fixture moved from 1.18.1 → 2.0.1; there is no 1.x
+  fallback, and consumers on 1.x must upgrade.
+- **The macOS-CEF caveats from ADR-0004 stand** — deeplink and multiremote on the macOS CEF path
+  remain upstream-blocked ([#320](https://github.com/webdriverio/desktop-mobile/issues/320)).

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -24,7 +24,7 @@ e2e/
 │   │   ├── api.spec.ts
 │   │   ├── mock.spec.ts
 │   │   └── ...
-│   └── electrobun/         # Electrobun E2E tests (macOS CEF: `standard`; Windows WebView2: standard+window+multiremote)
+│   └── electrobun/         # Electrobun E2E tests (macOS CEF: `standard`; Windows WebView2: standard+window+multiremote; Linux WebKitGTK: `standard`)
 │       ├── api.spec.ts
 │       └── ...
 ├── lib/                    # Shared test utilities
@@ -41,7 +41,7 @@ fixtures/e2e-apps/
 ├── electron-script/        # Electron app (script mode)
 ├── tauri/                  # Tauri app
 ├── dioxus/                 # Dioxus app
-└── electrobun/             # Electrobun app (CEF on macOS / native WebView2 on Windows)
+└── electrobun/             # Electrobun app (CEF on macOS / native WebView2 on Windows / native WebKitGTK on Linux)
 ```
 
 ## Running E2E Tests


### PR DESCRIPTION
Stacked on #631. Updates the **repo-level** docs for the Linux WebKitGTK (W3C WebDriver) support #631 adds — that PR updated the package README, but the root README, roadmap, e2e guide, and `AGENTS.md` still described electrobun as macOS/Windows-only with Linux upstream-blocked.

### Changes
- **README / ROADMAP / AGENTS / e2e-testing** — add Linux (native WebKitGTK over W3C WebDriver, `electrobun ≥ 2.0.1`, single-window); drop the Linux-blocked notes; keep the macOS-CEF deeplink/multiremote caveats.
- **ADR-0005** (new) — records adopting **Electrobun 2.0+ only** (dropping 1.x). These are one decision, not two: 2.0 is what exposes WebKitGTK automation ([electrobun#467](https://github.com/blackboardsh/electrobun/issues/467)), so Linux is only possible there — 1.x can't do it. Track-latest is justified for a new, few-users framework. Amends ADR-0004 (which keeps a short "Amended by" note).

### Notes
- Base is #631's branch (stacked); retargets to `main` once #631 merges.
- Docs-only — no code/tests affected.
- Deliberately left correct: `native-cdp-bridge` README lists only macOS/Windows for electrobun (Linux uses W3C, not the CDP bridge); the package README's `triggerDeeplink` row keeps "Windows/Linux upstream-blocked" (deeplink is a separate upstream gap, #465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKbL963N3nrMSaQW3V413K
